### PR TITLE
fixed bug in predicate map implementation

### DIFF
--- a/pyreason/scripts/interpretation/interpretation.py
+++ b/pyreason/scripts/interpretation/interpretation.py
@@ -1860,6 +1860,11 @@ def _add_edge(source, target, neighbors, reverse_neighbors, nodes, edges, l, int
 			interpretations_edge[edge].world[l] = interval.closed(0, 1)
 			num_ga[t] += 1
 
+			if l in predicate_map:
+				predicate_map[l].append(edge)
+			else:
+				predicate_map[l] = numba.typed.List([edge])
+
 	return edge, new_edge
 
 

--- a/pyreason/scripts/interpretation/interpretation.py
+++ b/pyreason/scripts/interpretation/interpretation.py
@@ -140,12 +140,10 @@ class Interpretation:
 
 		# Specific labels
 		for l, ns in specific_labels.items():
+			predicate_map[l] = numba.typed.List(ns)
 			for n in ns:
 				interpretations[n].world[l] = interval.closed(0.0, 1.0)
 				num_ga[0] += 1
-
-		for l, ns in specific_labels.items():
-			predicate_map[l] = numba.typed.List(ns)
 
 		return interpretations, predicate_map
 
@@ -161,12 +159,10 @@ class Interpretation:
 
 		# Specific labels
 		for l, es in specific_labels.items():
+			predicate_map[l] = numba.typed.List(es)
 			for e in es:
 				interpretations[e].world[l] = interval.closed(0.0, 1.0)
 				num_ga[0] += 1
-
-		for l, es in specific_labels.items():
-			predicate_map[l] = numba.typed.List(es)
 
 		return interpretations, predicate_map
 

--- a/pyreason/scripts/interpretation/interpretation_parallel.py
+++ b/pyreason/scripts/interpretation/interpretation_parallel.py
@@ -1860,6 +1860,11 @@ def _add_edge(source, target, neighbors, reverse_neighbors, nodes, edges, l, int
 			interpretations_edge[edge].world[l] = interval.closed(0, 1)
 			num_ga[t] += 1
 
+			if l in predicate_map:
+				predicate_map[l].append(edge)
+			else:
+				predicate_map[l] = numba.typed.List([edge])
+
 	return edge, new_edge
 
 

--- a/pyreason/scripts/interpretation/interpretation_parallel.py
+++ b/pyreason/scripts/interpretation/interpretation_parallel.py
@@ -140,12 +140,10 @@ class Interpretation:
 
 		# Specific labels
 		for l, ns in specific_labels.items():
+			predicate_map[l] = numba.typed.List(ns)
 			for n in ns:
 				interpretations[n].world[l] = interval.closed(0.0, 1.0)
 				num_ga[0] += 1
-
-		for l, ns in specific_labels.items():
-			predicate_map[l] = numba.typed.List(ns)
 
 		return interpretations, predicate_map
 
@@ -161,12 +159,10 @@ class Interpretation:
 
 		# Specific labels
 		for l, es in specific_labels.items():
+			predicate_map[l] = numba.typed.List(es)
 			for e in es:
 				interpretations[e].world[l] = interval.closed(0.0, 1.0)
 				num_ga[0] += 1
-
-		for l, es in specific_labels.items():
-			predicate_map[l] = numba.typed.List(es)
 
 		return interpretations, predicate_map
 
@@ -222,7 +218,7 @@ class Interpretation:
 			print('Fixed Point iterations:', fp_cnt)
 
 	@staticmethod
-	@numba.njit(cache=True, parallel=True)
+	@numba.njit(cache=True, parallel=False)
 	def reason(interpretations_node, interpretations_edge, predicate_map_node, predicate_map_edge, tmax, prev_reasoning_data, rules, nodes, edges, neighbors, reverse_neighbors, rules_to_be_applied_node, rules_to_be_applied_edge, edges_to_be_added_node_rule, edges_to_be_added_edge_rule, rules_to_be_applied_node_trace, rules_to_be_applied_edge_trace, facts_to_be_applied_node, facts_to_be_applied_edge, facts_to_be_applied_node_trace, facts_to_be_applied_edge_trace, ipl, rule_trace_node, rule_trace_edge, rule_trace_node_atoms, rule_trace_edge_atoms, reverse_graph, atom_trace, save_graph_attributes_to_rule_trace, persistent, inconsistency_check, store_interpretation_changes, update_mode, allow_ground_rules, max_facts_time, annotation_functions, convergence_mode, convergence_delta, num_ga, verbose, again):
 		t = prev_reasoning_data[0]
 		fp_cnt = prev_reasoning_data[1]

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ long_description = (this_directory / "README.md").read_text(encoding='UTF-8')
 
 setup(
     name='pyreason',
-    version='3.0.0',
+    version='3.0.1',
     author='Dyuman Aditya',
     author_email='dyuman.aditya@gmail.com',
     description='An explainable inference software supporting annotated, real valued, graph based and temporal logic',


### PR DESCRIPTION
Grounding bug with predicate map implementation

This pull request includes changes to the `_add_edge` function in two files to enhance the handling of the `predicate_map` dictionary. The most important changes are as follows:

Enhancements to `_add_edge` function:

* [`pyreason/scripts/interpretation/interpretation.py`](diffhunk://#diff-e4cf66c4b7846cfe98e7b5cc2d81d35eb43a51515361cea1a407e937a82e6406R1863-R1867): Added logic to check if `l` is in `predicate_map`. If it is, append `edge` to the list; otherwise, initialize a new `numba.typed.List` with `edge`.
* [`pyreason/scripts/interpretation/interpretation_parallel.py`](diffhunk://#diff-340ccff1e9fc3136067c218a4b648b7eb0dd79ffd855abeb941533bd016d79caR1863-R1867): Added similar logic to handle `predicate_map` as in `interpretation.py`.