### PR TITLE
Add support partial edge grounding

### DIFF
--- a/pyreason/scripts/interpretation/interpretation.py
+++ b/pyreason/scripts/interpretation/interpretation.py
@@ -862,6 +862,12 @@ def _ground_rule(rule, interpretations_node, interpretations_edge, predicate_map
 			if allow_ground_rules and (clause_var_1, clause_var_2) in edges_set:
 				grounding = numba.typed.List([(clause_var_1, clause_var_2)])
 			else:
+				# Pre-populate groundings for any variable that matches an existing node (partial grounding)
+				if allow_ground_rules:
+					if clause_var_1 in nodes_set and clause_var_1 not in groundings:
+						groundings[clause_var_1] = numba.typed.List([clause_var_1])
+					if clause_var_2 in nodes_set and clause_var_2 not in groundings:
+						groundings[clause_var_2] = numba.typed.List([clause_var_2])
 				grounding = get_rule_edge_clause_grounding(clause_var_1, clause_var_2, groundings, groundings_edges, neighbors, reverse_neighbors, predicate_map_edge, clause_label, edges)
 
 			# Narrow subset based on predicate (save the edges that are qualified to use for finding future groundings faster)

--- a/pyreason/scripts/interpretation/interpretation_fp.py
+++ b/pyreason/scripts/interpretation/interpretation_fp.py
@@ -984,6 +984,12 @@ def _ground_rule(rule, interpretations_node, interpretations_edge, predicate_map
 			if allow_ground_rules and (clause_var_1, clause_var_2) in edges_set:
 				grounding = numba.typed.List([(clause_var_1, clause_var_2)])
 			else:
+				# Pre-populate groundings for any variable that matches an existing node (partial grounding)
+				if allow_ground_rules:
+					if clause_var_1 in nodes_set and clause_var_1 not in groundings:
+						groundings[clause_var_1] = numba.typed.List([clause_var_1])
+					if clause_var_2 in nodes_set and clause_var_2 not in groundings:
+						groundings[clause_var_2] = numba.typed.List([clause_var_2])
 				grounding = get_rule_edge_clause_grounding(clause_var_1, clause_var_2, groundings, groundings_edges, neighbors, reverse_neighbors, predicate_map_edge, clause_label, edges)
 
 			# Narrow subset based on predicate (save the edges that are qualified to use for finding future groundings faster)

--- a/pyreason/scripts/interpretation/interpretation_parallel.py
+++ b/pyreason/scripts/interpretation/interpretation_parallel.py
@@ -862,6 +862,12 @@ def _ground_rule(rule, interpretations_node, interpretations_edge, predicate_map
 			if allow_ground_rules and (clause_var_1, clause_var_2) in edges_set:
 				grounding = numba.typed.List([(clause_var_1, clause_var_2)])
 			else:
+				# Pre-populate groundings for any variable that matches an existing node (partial grounding)
+				if allow_ground_rules:
+					if clause_var_1 in nodes_set and clause_var_1 not in groundings:
+						groundings[clause_var_1] = numba.typed.List([clause_var_1])
+					if clause_var_2 in nodes_set and clause_var_2 not in groundings:
+						groundings[clause_var_2] = numba.typed.List([clause_var_2])
 				grounding = get_rule_edge_clause_grounding(clause_var_1, clause_var_2, groundings, groundings_edges, neighbors, reverse_neighbors, predicate_map_edge, clause_label, edges)
 
 			# Narrow subset based on predicate (save the edges that are qualified to use for finding future groundings faster)

--- a/tests/functional/test_edge_inference.py
+++ b/tests/functional/test_edge_inference.py
@@ -1,5 +1,6 @@
 # Edge inference rule tests for PyReason
 import pyreason as pr
+import networkx as nx
 import pytest
 
 
@@ -125,3 +126,91 @@ def test_anyBurl_rule_4(mode):
     assert len(dataframes) == 2, 'Pyreason should run exactly 1 fixpoint operations'
     assert len(dataframes[1]) == 1, 'At t=1 there should be only 1 new isConnectedTo atom'
     assert ('Yali', 'Vnukovo_International_Airport') in dataframes[1]['component'].values.tolist() and dataframes[1]['isConnectedTo'].iloc[0] == [1, 1], '(Yali, Vnukovo_International_Airport) should have isConnectedTo bounds [1,1] for t=1 timesteps'
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("mode", ["regular", "fp", "parallel"])
+def test_partial_edge_grounding(mode):
+    """Test that ground node names in edge clauses are pre-populated as groundings.
+
+    When a rule has an edge clause like trusts(Alice, y) where Alice is a known
+    node but the specific edge pair isn't enumerated, partial grounding ensures
+    Alice is recognized and edges from Alice are discovered via neighbor lookups.
+    """
+    setup_mode(mode)
+    pr.settings.allow_ground_rules = True
+
+    # Build a small graph: Alice trusts Bob, Bob trusts Carol
+    # Alice has the 'admin' attribute
+    graph = nx.DiGraph()
+    graph.add_node("Alice", admin=1)
+    graph.add_node("Bob", admin=0)
+    graph.add_node("Carol", admin=0)
+    graph.add_edge("Alice", "Bob", trusts=1)
+    graph.add_edge("Bob", "Carol", trusts=1)
+    pr.load_graph(graph)
+
+    # Rule: if Alice is admin and Alice trusts someone, infer can_access edge
+    # The edge clause trusts(Alice, y) uses a ground node name (Alice) + free variable (y)
+    # Partial grounding pre-populates Alice so neighbor lookup finds the edge to Bob
+    pr.add_rule(pr.Rule(
+        'can_access(Alice, y) <-1 admin(Alice), trusts(Alice, y)',
+        'partial_ground_rule',
+        infer_edges=True,
+    ))
+
+    interpretation = pr.reason(timesteps=1)
+
+    dataframes = pr.filter_and_sort_edges(interpretation, ['can_access'])
+    for t, df in enumerate(dataframes):
+        print(f'TIMESTEP - {t}')
+        print(df)
+        print()
+
+    assert len(dataframes) == 2, 'Should have 2 timesteps of results'
+    assert len(dataframes[1]) == 1, 'At t=1 there should be exactly 1 new can_access edge'
+    assert ('Alice', 'Bob') in dataframes[1]['component'].values.tolist(), \
+        'can_access(Alice, Bob) should be inferred'
+    assert dataframes[1]['can_access'].iloc[0] == [1, 1], \
+        'can_access(Alice, Bob) should have bounds [1,1]'
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("mode", ["regular", "fp", "parallel"])
+def test_partial_edge_grounding_reverse(mode):
+    """Test partial grounding when the ground node is in the second position of the edge clause.
+
+    Rule: can_reach(y, Carol) <- trusts(y, Carol), admin(Carol)
+    Carol is ground in position 2 of the edge clause.
+    """
+    setup_mode(mode)
+    pr.settings.allow_ground_rules = True
+
+    graph = nx.DiGraph()
+    graph.add_node("Alice", admin=0)
+    graph.add_node("Bob", admin=0)
+    graph.add_node("Carol", admin=1)
+    graph.add_edge("Alice", "Bob", trusts=1)
+    graph.add_edge("Bob", "Carol", trusts=1)
+    pr.load_graph(graph)
+
+    pr.add_rule(pr.Rule(
+        'can_reach(y, Carol) <-1 admin(Carol), trusts(y, Carol)',
+        'partial_ground_reverse_rule',
+        infer_edges=True,
+    ))
+
+    interpretation = pr.reason(timesteps=1)
+
+    dataframes = pr.filter_and_sort_edges(interpretation, ['can_reach'])
+    for t, df in enumerate(dataframes):
+        print(f'TIMESTEP - {t}')
+        print(df)
+        print()
+
+    assert len(dataframes) == 2, 'Should have 2 timesteps of results'
+    assert len(dataframes[1]) == 1, 'At t=1 there should be exactly 1 new can_reach edge'
+    assert ('Bob', 'Carol') in dataframes[1]['component'].values.tolist(), \
+        'can_reach(Bob, Carol) should be inferred'
+    assert dataframes[1]['can_reach'].iloc[0] == [1, 1], \
+        'can_reach(Bob, Carol) should have bounds [1,1]'


### PR DESCRIPTION
## Summary
- Pre-populate groundings for variables that match existing nodes when processing edge clauses in ground rules
- Applied consistently across all three interpretation modules (`interpretation.py`, `interpretation_fp.py`, `interpretation_parallel.py`)

## Test plan
- [ ] Run existing functional tests to verify no regressions
- [ ] Test with rules that use partial edge grounding (one variable is a known node)