### PR TITLE
Relax parsing requirements to allow hyphens and periods

### DIFF
--- a/pyreason/scripts/utils/fact_parser.py
+++ b/pyreason/scripts/utils/fact_parser.py
@@ -2,7 +2,7 @@ import pyreason.scripts.numba_wrapper.numba_types.interval_type as interval
 import re
 
 _PREDICATE_RE = re.compile(r'^[a-zA-Z_][a-zA-Z0-9_.\-]*$')
-_COMPONENT_RE = re.compile(r'^[a-zA-Z0-9_][a-zA-Z0-9_.\-]*$')
+_COMPONENT_RE = re.compile(r'^[a-zA-Z0-9_][a-zA-Z0-9_.@\-]*$')
 
 
 def _validate_predicate(name):
@@ -21,7 +21,7 @@ def _validate_component(name, context):
     if not name:
         raise ValueError(f"{context} name cannot be empty")
     if not _COMPONENT_RE.match(name):
-        raise ValueError(f"{context} name '{name}' contains invalid characters. Must match [a-zA-Z0-9_][a-zA-Z0-9_.\\-]*")
+        raise ValueError(f"{context} name '{name}' contains invalid characters. Must match [a-zA-Z0-9_][a-zA-Z0-9_.@\\-]*")
 
 
 # Input validation work was implemented with the help of Claude Sonnet 4.5.

--- a/pyreason/scripts/utils/fact_parser.py
+++ b/pyreason/scripts/utils/fact_parser.py
@@ -1,6 +1,19 @@
 import pyreason.scripts.numba_wrapper.numba_types.interval_type as interval
 import re
 
+_IDENTIFIER_RE = re.compile(r'^[a-zA-Z_][a-zA-Z0-9_.\-]*$')
+
+
+def _validate_name(name, context):
+    """Validate that a predicate or component name matches _IDENTIFIER_RE."""
+    if not name:
+        raise ValueError(f"{context} name cannot be empty")
+    if not _IDENTIFIER_RE.match(name):
+        if name[0].isdigit():
+            raise ValueError(f"{context} name '{name}' cannot start with a digit. Must start with a letter or underscore")
+        else:
+            raise ValueError(f"{context} name '{name}' contains invalid characters. Must match [a-zA-Z_][a-zA-Z0-9_.\\-]*")
+
 
 # Input validation work was implemented with the help of Claude Sonnet 4.5.
 def parse_fact(fact_text):
@@ -75,27 +88,12 @@ def parse_fact(fact_text):
     pred = pred_comp[:idx]
     component = pred_comp[idx + 1:-1]
 
-    # Validate predicate is not empty
-    if not pred:
-        raise ValueError("Predicate cannot be empty")
-
-    # Validate predicate contains only valid characters (alphanumeric and underscore)
-    # Predicates must start with a letter or underscore (like Python identifiers)
-    if not re.match(r'^[a-zA-Z_][a-zA-Z0-9_]*$', pred):
-        if pred[0].isdigit():
-            raise ValueError(f"Predicate '{pred}' cannot start with a digit. Must start with a letter or underscore")
-        else:
-            raise ValueError(f"Predicate '{pred}' contains invalid characters. Only letters, digits, and underscores allowed, must start with letter or underscore")
+    # Validate predicate name
+    _validate_name(pred, "Predicate")
 
     # Validate component is not empty
     if not component:
         raise ValueError("Component cannot be empty")
-
-    # Check for invalid characters in component
-    if '(' in component or ')' in component:
-        raise ValueError("Component cannot contain parentheses")
-    if ':' in component:
-        raise ValueError("Component cannot contain colons")
 
     # Check if it is a node or edge fact
     if ',' in component:
@@ -106,14 +104,14 @@ def parse_fact(fact_text):
         if len(components) != 2:
             raise ValueError(f"Edge facts must have exactly 2 components, found {len(components)}")
 
-        # Validate no empty components
+        # Validate component names
         for i, comp in enumerate(components):
-            if not comp:
-                raise ValueError(f"Component {i+1} in edge fact cannot be empty")
+            _validate_name(comp, f"Edge component {i+1}")
 
         component = tuple(components)
     else:
         fact_type = 'node'
+        _validate_name(component, "Node component")
 
     # Check if bound is a boolean or a list of floats
     if bound.lower() == 'true':

--- a/pyreason/scripts/utils/fact_parser.py
+++ b/pyreason/scripts/utils/fact_parser.py
@@ -1,18 +1,27 @@
 import pyreason.scripts.numba_wrapper.numba_types.interval_type as interval
 import re
 
-_IDENTIFIER_RE = re.compile(r'^[a-zA-Z_][a-zA-Z0-9_.\-]*$')
+_PREDICATE_RE = re.compile(r'^[a-zA-Z_][a-zA-Z0-9_.\-]*$')
+_COMPONENT_RE = re.compile(r'^[a-zA-Z0-9_][a-zA-Z0-9_.\-]*$')
 
 
-def _validate_name(name, context):
-    """Validate that a predicate or component name matches _IDENTIFIER_RE."""
+def _validate_predicate(name):
+    """Validate that a predicate name starts with a letter/underscore."""
+    if not name:
+        raise ValueError("Predicate name cannot be empty")
+    if not _PREDICATE_RE.match(name):
+        if name[0].isdigit():
+            raise ValueError(f"Predicate name '{name}' cannot start with a digit. Must start with a letter or underscore")
+        else:
+            raise ValueError(f"Predicate name '{name}' contains invalid characters. Must match [a-zA-Z_][a-zA-Z0-9_.\\-]*")
+
+
+def _validate_component(name, context):
+    """Validate that a component (entity) name contains only valid characters. May start with a digit."""
     if not name:
         raise ValueError(f"{context} name cannot be empty")
-    if not _IDENTIFIER_RE.match(name):
-        if name[0].isdigit():
-            raise ValueError(f"{context} name '{name}' cannot start with a digit. Must start with a letter or underscore")
-        else:
-            raise ValueError(f"{context} name '{name}' contains invalid characters. Must match [a-zA-Z_][a-zA-Z0-9_.\\-]*")
+    if not _COMPONENT_RE.match(name):
+        raise ValueError(f"{context} name '{name}' contains invalid characters. Must match [a-zA-Z0-9_][a-zA-Z0-9_.\\-]*")
 
 
 # Input validation work was implemented with the help of Claude Sonnet 4.5.
@@ -89,7 +98,7 @@ def parse_fact(fact_text):
     component = pred_comp[idx + 1:-1]
 
     # Validate predicate name
-    _validate_name(pred, "Predicate")
+    _validate_predicate(pred)
 
     # Validate component is not empty
     if not component:
@@ -106,12 +115,12 @@ def parse_fact(fact_text):
 
         # Validate component names
         for i, comp in enumerate(components):
-            _validate_name(comp, f"Edge component {i+1}")
+            _validate_component(comp, f"Edge component {i+1}")
 
         component = tuple(components)
     else:
         fact_type = 'node'
-        _validate_name(component, "Node component")
+        _validate_component(component, "Node component")
 
     # Check if bound is a boolean or a list of floats
     if bound.lower() == 'true':

--- a/pyreason/scripts/utils/rule_parser.py
+++ b/pyreason/scripts/utils/rule_parser.py
@@ -10,7 +10,7 @@ import pyreason.scripts.numba_wrapper.numba_types.label_type as label
 import pyreason.scripts.numba_wrapper.numba_types.interval_type as interval
 from pyreason.scripts.threshold.threshold import Threshold
 
-_IDENTIFIER_RE = re.compile(r'^[a-zA-Z_][a-zA-Z0-9_]*$')
+_IDENTIFIER_RE = re.compile(r'^[a-zA-Z_][a-zA-Z0-9_.\-]*$')
 
 
 def parse_rule(rule_text: str, name: str, custom_thresholds: Union[None, list, dict], infer_edges: bool = False, set_static: bool = False, weights: Union[None, np.ndarray] = None) -> rule.Rule:
@@ -486,7 +486,7 @@ def _validate_predicate_name(pred, context):
     if not _IDENTIFIER_RE.match(pred):
         if pred and pred[0].isdigit():
             raise ValueError(f"{context} predicate name '{pred}' cannot start with a digit")
-        raise ValueError(f"{context} predicate name '{pred}' contains invalid characters. Must match [a-zA-Z_][a-zA-Z0-9_]*")
+        raise ValueError(f"{context} predicate name '{pred}' contains invalid characters. Must match [a-zA-Z_][a-zA-Z0-9_.\\-]*")
 
 
 def _validate_component_name(var, context):
@@ -494,7 +494,7 @@ def _validate_component_name(var, context):
     if not _IDENTIFIER_RE.match(var):
         if var and var[0].isdigit():
             raise ValueError(f"{context} component name '{var}' cannot start with a digit")
-        raise ValueError(f"{context} component name '{var}' contains invalid characters. Must match [a-zA-Z_][a-zA-Z0-9_]*")
+        raise ValueError(f"{context} component name '{var}' contains invalid characters. Must match [a-zA-Z_][a-zA-Z0-9_.\\-]*")
 
 
 def _str_bound_to_bound(str_bound):

--- a/pyreason/scripts/utils/rule_parser.py
+++ b/pyreason/scripts/utils/rule_parser.py
@@ -10,7 +10,8 @@ import pyreason.scripts.numba_wrapper.numba_types.label_type as label
 import pyreason.scripts.numba_wrapper.numba_types.interval_type as interval
 from pyreason.scripts.threshold.threshold import Threshold
 
-_IDENTIFIER_RE = re.compile(r'^[a-zA-Z_][a-zA-Z0-9_.\-]*$')
+_PREDICATE_RE = re.compile(r'^[a-zA-Z_][a-zA-Z0-9_.\-]*$')
+_COMPONENT_RE = re.compile(r'^[a-zA-Z0-9_][a-zA-Z0-9_.@\-]*$')
 
 
 def parse_rule(rule_text: str, name: str, custom_thresholds: Union[None, list, dict], infer_edges: bool = False, set_static: bool = False, weights: Union[None, np.ndarray] = None) -> rule.Rule:
@@ -482,19 +483,17 @@ def _parse_head_arguments(head_args_str):
 
 
 def _validate_predicate_name(pred, context):
-    """Validate that a predicate name matches ^[a-zA-Z_][a-zA-Z0-9_]*$."""
-    if not _IDENTIFIER_RE.match(pred):
+    """Validate that a predicate name matches ^[a-zA-Z_][a-zA-Z0-9_.\\-]*$."""
+    if not _PREDICATE_RE.match(pred):
         if pred and pred[0].isdigit():
             raise ValueError(f"{context} predicate name '{pred}' cannot start with a digit")
         raise ValueError(f"{context} predicate name '{pred}' contains invalid characters. Must match [a-zA-Z_][a-zA-Z0-9_.\\-]*")
 
 
 def _validate_component_name(var, context):
-    """Validate that a variable name matches ^[a-zA-Z_][a-zA-Z0-9_]*$."""
-    if not _IDENTIFIER_RE.match(var):
-        if var and var[0].isdigit():
-            raise ValueError(f"{context} component name '{var}' cannot start with a digit")
-        raise ValueError(f"{context} component name '{var}' contains invalid characters. Must match [a-zA-Z_][a-zA-Z0-9_.\\-]*")
+    """Validate that a component name matches ^[a-zA-Z0-9_][a-zA-Z0-9_.@\\-]*$."""
+    if not _COMPONENT_RE.match(var):
+        raise ValueError(f"{context} component name '{var}' contains invalid characters. Must match [a-zA-Z0-9_][a-zA-Z0-9_.@\\-]*")
 
 
 def _str_bound_to_bound(str_bound):

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ long_description = (this_directory / "README.md").read_text(encoding='UTF-8')
 
 setup(
     name='pyreason',
-    version='3.5.0',
+    version='3.5.1',
     author='Dyuman Aditya',
     author_email='dyuman.aditya@gmail.com',
     description='An explainable inference software supporting annotated, real valued, graph based and temporal logic',

--- a/tests/api_tests/test_pyreason_reasoning.py
+++ b/tests/api_tests/test_pyreason_reasoning.py
@@ -149,7 +149,7 @@ class TestReasoningFunction:
         pr.add_rule(Rule("friend(A, B) <- person(A), person(B)", "test_rule", False))
 
         # Add some facts first to create existing specific labels
-        pr.add_fact(Fact('person("C")', 'person_c', 0, 1))
+        pr.add_fact(Fact('person(C)', 'person_c', 0, 1))
 
         interpretation = pr.reason(timesteps=1)
         assert interpretation is not None
@@ -292,7 +292,7 @@ class TestReasoningFunction:
         pr.add_rule(Rule("friend(A, B) <- connected(A, B)", "test_rule", False))
 
         # Add some facts
-        pr.add_fact(Fact('person("A")', 'person_a', 0, 1))
+        pr.add_fact(Fact('person(A)', 'person_a', 0, 1))
 
         interpretation = pr.reason(timesteps=1)
         assert interpretation is not None
@@ -352,7 +352,7 @@ class TestReasonAgainFunction:
         assert interpretation1 is not None
 
         # Add new facts and reason again
-        pr.add_fact(Fact('person("A")', 'person_a', 0, 1))
+        pr.add_fact(Fact('person(A)', 'person_a', 0, 1))
         interpretation2 = pr.reason(timesteps=1)
         assert interpretation2 is not None
 
@@ -657,7 +657,7 @@ class TestFilterAndSortFunctions:
         # Add multiple rules
         pr.add_rule(Rule("friend(A, B) <- connected(A, B)", "rule1", False))
         pr.add_rule(Rule("close_friend(A, B) <- friend(A, B)", "rule2", False))
-        pr.add_fact(Fact('person("A")', 'fact1', 0, 2))
+        pr.add_fact(Fact('person(A)', 'fact1', 0, 2))
 
         pr.settings.store_interpretation_changes = True
         interpretation = pr.reason(timesteps=3)
@@ -736,7 +736,7 @@ class TestReasonFunctionBranches:
         assert interpretation1 is not None
 
         # Add facts for reason_again to work with
-        pr.add_fact(Fact('person("A")', 'person_a', 0, 1))
+        pr.add_fact(Fact('person(A)', 'person_a', 0, 1))
 
         # Enable memory profiling
         pr.settings.memory_profile = True
@@ -776,7 +776,7 @@ class TestReasonFunctionBranches:
         assert interpretation1 is not None
 
         # Add facts for reason_again to work with
-        pr.add_fact(Fact('person("A")', 'person_a', 0, 1))
+        pr.add_fact(Fact('person(A)', 'person_a', 0, 1))
 
         # Ensure memory profiling is disabled
         pr.settings.memory_profile = False
@@ -798,14 +798,14 @@ class TestReasonFunctionBranches:
         assert interpretation1 is not None
 
         # Add facts for reason_again calls
-        pr.add_fact(Fact('person("A")', 'person_a', 0, 1))
+        pr.add_fact(Fact('person(A)', 'person_a', 0, 1))
 
         # Test again=True with restart=True (should use _reason_again)
         interpretation2 = pr.reason(timesteps=1, again=True, restart=True)
         assert interpretation2 is not None
 
         # Add more facts for next call
-        pr.add_fact(Fact('person("B")', 'person_b', 0, 1))
+        pr.add_fact(Fact('person(B)', 'person_b', 0, 1))
 
         # Test again=True with restart=False (should use _reason_again)
         interpretation3 = pr.reason(timesteps=1, again=True, restart=False)
@@ -841,7 +841,7 @@ class TestReasonFunctionBranches:
         assert interpretation1 is not None
 
         # Add some facts to test the fact extension logic in _reason_again
-        pr.add_fact(Fact('person("A")', 'person_a', 0, 1))
+        pr.add_fact(Fact('person(A)', 'person_a', 0, 1))
 
         # This should exercise the fact extension branches in _reason_again
         interpretation2 = pr.reason(timesteps=2, again=True, restart=True)
@@ -859,7 +859,7 @@ class TestReasonFunctionBranches:
         assert interpretation1 is not None
 
         # Add facts for reason_again
-        pr.add_fact(Fact('person("A")', 'person_a', 0, 1))
+        pr.add_fact(Fact('person(A)', 'person_a', 0, 1))
 
         # Enable verbose mode
         pr.settings.verbose = True
@@ -899,7 +899,7 @@ class TestReasonFunctionBranches:
             pr.settings.memory_profile = False
 
         # Add facts for again=True tests
-        pr.add_fact(Fact('person("A")', 'person_a', 0, 1))
+        pr.add_fact(Fact('person(A)', 'person_a', 0, 1))
 
         # Test case 3: again=True, memory_profile=False
         pr.settings.memory_profile = False
@@ -907,7 +907,7 @@ class TestReasonFunctionBranches:
         assert interpretation3 is not None
 
         # Add more facts for next test
-        pr.add_fact(Fact('person("B")', 'person_b', 0, 1))
+        pr.add_fact(Fact('person(B)', 'person_b', 0, 1))
 
         # Test case 4: again=True, memory_profile=True
         pr.settings.memory_profile = True
@@ -933,7 +933,7 @@ class TestReasonFunctionBranches:
         assert interpretation1 is not None
 
         # Add facts for reason_again
-        pr.add_fact(Fact('person("A")', 'person_a', 0, 1))
+        pr.add_fact(Fact('person(A)', 'person_a', 0, 1))
 
         # Now the assert in _reason_again should pass
         interpretation2 = pr.reason(timesteps=1, again=True)

--- a/tests/unit/dont_disable_jit/test_rule_parser.py
+++ b/tests/unit/dont_disable_jit/test_rule_parser.py
@@ -675,11 +675,6 @@ class TestEdgeCasesAndBoundary:
         with pytest.raises(ValueError, match="Double negation"):
             parse_rule("p(X) <- ~~b(X)", "r", None)
 
-    def test_head_variable_starts_with_digit(self):
-        """Head variable starting with digit raises ValueError."""
-        with pytest.raises(ValueError, match="digit"):
-            parse_rule("p(1X) <- b(Y)", "r", None)
-
     def test_body_variable_invalid_chars(self):
         """Body variable with invalid chars raises ValueError."""
         with pytest.raises(ValueError, match="invalid characters"):

--- a/tests/unit/dont_disable_jit/test_rule_parser.py
+++ b/tests/unit/dont_disable_jit/test_rule_parser.py
@@ -653,7 +653,7 @@ class TestEdgeCasesAndBoundary:
     def test_head_predicate_invalid_chars(self):
         """Head predicate with invalid chars raises ValueError."""
         with pytest.raises(ValueError, match="invalid characters"):
-            parse_rule("pred-name(X) <- b(X)", "r", None)
+            parse_rule("pred!name(X) <- b(X)", "r", None)
 
     def test_body_predicate_starts_with_digit(self):
         """Body predicate starting with digit raises ValueError."""
@@ -663,7 +663,7 @@ class TestEdgeCasesAndBoundary:
     def test_body_predicate_invalid_chars(self):
         """Body predicate with invalid chars raises ValueError."""
         with pytest.raises(ValueError, match="invalid characters"):
-            parse_rule("p(X) <- body-name(X)", "r", None)
+            parse_rule("p(X) <- body!name(X)", "r", None)
 
     def test_double_negation_head(self):
         """Double negation in head raises ValueError."""
@@ -683,7 +683,7 @@ class TestEdgeCasesAndBoundary:
     def test_body_variable_invalid_chars(self):
         """Body variable with invalid chars raises ValueError."""
         with pytest.raises(ValueError, match="invalid characters"):
-            parse_rule("p(X) <- b(X-Y)", "r", None)
+            parse_rule("p(X) <- b(X!Y)", "r", None)
 
     def test_empty_head_parentheses(self):
         """Empty head parentheses raises ValueError."""


### PR DESCRIPTION
## Summary

Relaxes identifier/entity validation across the fact and rule parsers, splits the rule parser's single identifier regex into separate predicate/component regexes, and aligns fact and rule component rules so any entity valid as a fact can also appear as a grounded atom in a rule.

### Final regex layout

| Role | Regex | Leading digit? | `.` / `-` | `@` |
|---|---|---|---|---|
| Fact predicate | `[a-zA-Z_][a-zA-Z0-9_.\-]*` | no | yes | no |
| Fact component | `[a-zA-Z0-9_][a-zA-Z0-9_.@\-]*` | yes | yes | yes |
| Rule predicate | `[a-zA-Z_][a-zA-Z0-9_.\-]*` | no | yes | no |
| Rule component | `[a-zA-Z0-9_][a-zA-Z0-9_.@\-]*` | yes | yes | yes |

Fact and rule components share the same regex. Predicates are stricter than components (no leading digit, no `@`).

### Changes

**`pyreason/scripts/utils/fact_parser.py`**
- Added `_PREDICATE_RE` and `_COMPONENT_RE`.
- Added `_validate_predicate()` and `_validate_component()` helpers.
- Replaces inline predicate checks and ad-hoc `(`, `)`, `:` bans on components — covered by the regex.
- **Node components are now validated** (previously only edge components had any validation, and only an empty-check).

**`pyreason/scripts/utils/rule_parser.py`**
- Split `_IDENTIFIER_RE` into `_PREDICATE_RE` (identifiers) and `_COMPONENT_RE` (entities — matches `fact_parser._COMPONENT_RE`).
- `_validate_component_name` now uses `_COMPONENT_RE`; removed the now-unreachable digit-start error branch.
- Error messages updated to reflect the new allowed sets.

**`tests/unit/dont_disable_jit/test_rule_parser.py`**
- Negative-case inputs switched from `-` (now valid) to `!` (still invalid) in three tests.
- Removed `test_head_variable_starts_with_digit` — digit-leading rule components are now valid by design.

**`tests/api_tests/test_pyreason_reasoning.py`**
- 13 facts changed from `person("A")` to `person(A)` — quoted entity names are no longer valid under the stricter component allowlist.

## Test plan
- [x] Parser unit tests pass (168/168)
- [x] All 11 previously-failing API reasoning tests pass after the quoted→unquoted fix
- [x] Smoke tests confirm:
  - Facts with hyphens/periods/digits/`@` parse: `has-vuln(node-1)`, `cve.2024.1234(host.a, host.b)`, `person(123)`, `user(alice@example.com)`
  - Rule components accept the same entity shapes: `p(1X) <- b(1X)`, `p(a@b) <- q(a@b)`
  - Invalid chars (`!`, `"`, leading `@`, `~`, `/`) are still rejected

> [!NOTE]
> The branch name and first commit mention "spaces" but spaces are **not** allowed — only `-`, `.`, and `@` were added across the changes.
