### PR TITLE
Add rule negation with annotation fn

### DIFF
--- a/pyreason/.cache_status.yaml
+++ b/pyreason/.cache_status.yaml
@@ -1,1 +1,1 @@
-initialized: false
+initialized: true

--- a/pyreason/.cache_status.yaml
+++ b/pyreason/.cache_status.yaml
@@ -1,0 +1,1 @@
+initialized: false

--- a/pyreason/.cache_status.yaml
+++ b/pyreason/.cache_status.yaml
@@ -1,1 +1,0 @@
-initialized: true

--- a/pyreason/scripts/interpretation/interpretation.py
+++ b/pyreason/scripts/interpretation/interpretation.py
@@ -569,6 +569,9 @@ class Interpretation:
 								# If there is an edge to add or the predicate doesn't exist or the interpretation is not static
 								if rule.get_target() not in interpretations_node[n].world or not interpretations_node[n].world[rule.get_target()].is_static():
 									bnd = annotate(annotation_functions, rule, annotations, rule.get_weights())
+									# If the rule head was negated, invert the ann_fn output: ~[l,u] = [1-u, 1-l]
+									if rule.is_head_negated():
+										bnd = (1 - bnd[1], 1 - bnd[0])
 									# Bound annotations in between 0 and 1
 									bnd_l = min(max(bnd[0], 0), 1)
 									bnd_u = min(max(bnd[1], 0), 1)
@@ -588,6 +591,9 @@ class Interpretation:
 								# If there is an edge to add or the predicate doesn't exist or the interpretation is not static
 								if len(edges_to_add[0]) > 0 or rule.get_target() not in interpretations_edge[e].world or not interpretations_edge[e].world[rule.get_target()].is_static():
 									bnd = annotate(annotation_functions, rule, annotations, rule.get_weights())
+									# If the rule head was negated, invert the ann_fn output: ~[l,u] = [1-u, 1-l]
+									if rule.is_head_negated():
+										bnd = (1 - bnd[1], 1 - bnd[0])
 									# Bound annotations in between 0 and 1
 									bnd_l = min(max(bnd[0], 0), 1)
 									bnd_u = min(max(bnd[1], 0), 1)

--- a/pyreason/scripts/interpretation/interpretation.py
+++ b/pyreason/scripts/interpretation/interpretation.py
@@ -569,8 +569,10 @@ class Interpretation:
 								# If there is an edge to add or the predicate doesn't exist or the interpretation is not static
 								if rule.get_target() not in interpretations_node[n].world or not interpretations_node[n].world[rule.get_target()].is_static():
 									bnd = annotate(annotation_functions, rule, annotations, rule.get_weights())
-									# If the rule head was negated, invert the ann_fn output: ~[l,u] = [1-u, 1-l]
-									if rule.is_head_negated():
+									# If the rule head was negated AND an ann_fn produced the bound, invert it:
+									# ~[l,u] = [1-u, 1-l]. For non-ann_fn negation the parser already folded
+									# the inversion into target_bound, so we must NOT re-invert here.
+									if rule.get_annotation_function() != '' and rule.is_head_negated():
 										bnd = (1 - bnd[1], 1 - bnd[0])
 									# Bound annotations in between 0 and 1
 									bnd_l = min(max(bnd[0], 0), 1)
@@ -591,8 +593,10 @@ class Interpretation:
 								# If there is an edge to add or the predicate doesn't exist or the interpretation is not static
 								if len(edges_to_add[0]) > 0 or rule.get_target() not in interpretations_edge[e].world or not interpretations_edge[e].world[rule.get_target()].is_static():
 									bnd = annotate(annotation_functions, rule, annotations, rule.get_weights())
-									# If the rule head was negated, invert the ann_fn output: ~[l,u] = [1-u, 1-l]
-									if rule.is_head_negated():
+									# If the rule head was negated AND an ann_fn produced the bound, invert it:
+									# ~[l,u] = [1-u, 1-l]. For non-ann_fn negation the parser already folded
+									# the inversion into target_bound, so we must NOT re-invert here.
+									if rule.get_annotation_function() != '' and rule.is_head_negated():
 										bnd = (1 - bnd[1], 1 - bnd[0])
 									# Bound annotations in between 0 and 1
 									bnd_l = min(max(bnd[0], 0), 1)

--- a/pyreason/scripts/interpretation/interpretation_fp.py
+++ b/pyreason/scripts/interpretation/interpretation_fp.py
@@ -544,6 +544,9 @@ class Interpretation:
 
 							if should_apply_rule:
 								bnd = annotate(annotation_functions, rule, annotations, rule.get_weights())
+								# If the rule head was negated, invert the ann_fn output: ~[l,u] = [1-u, 1-l]
+								if rule.is_head_negated():
+									bnd = (1 - bnd[1], 1 - bnd[0])
 								# Bound annotations in between 0 and 1
 								bnd_l = min(max(bnd[0], 0), 1)
 								bnd_u = min(max(bnd[1], 0), 1)
@@ -581,6 +584,9 @@ class Interpretation:
 
 							if should_apply_rule:
 								bnd = annotate(annotation_functions, rule, annotations, rule.get_weights())
+								# If the rule head was negated, invert the ann_fn output: ~[l,u] = [1-u, 1-l]
+								if rule.is_head_negated():
+									bnd = (1 - bnd[1], 1 - bnd[0])
 								# Bound annotations in between 0 and 1
 								bnd_l = min(max(bnd[0], 0), 1)
 								bnd_u = min(max(bnd[1], 0), 1)

--- a/pyreason/scripts/interpretation/interpretation_fp.py
+++ b/pyreason/scripts/interpretation/interpretation_fp.py
@@ -544,8 +544,10 @@ class Interpretation:
 
 							if should_apply_rule:
 								bnd = annotate(annotation_functions, rule, annotations, rule.get_weights())
-								# If the rule head was negated, invert the ann_fn output: ~[l,u] = [1-u, 1-l]
-								if rule.is_head_negated():
+								# If the rule head was negated AND an ann_fn produced the bound, invert it:
+								# ~[l,u] = [1-u, 1-l]. For non-ann_fn negation the parser already folded
+								# the inversion into target_bound, so we must NOT re-invert here.
+								if rule.get_annotation_function() != '' and rule.is_head_negated():
 									bnd = (1 - bnd[1], 1 - bnd[0])
 								# Bound annotations in between 0 and 1
 								bnd_l = min(max(bnd[0], 0), 1)
@@ -584,8 +586,10 @@ class Interpretation:
 
 							if should_apply_rule:
 								bnd = annotate(annotation_functions, rule, annotations, rule.get_weights())
-								# If the rule head was negated, invert the ann_fn output: ~[l,u] = [1-u, 1-l]
-								if rule.is_head_negated():
+								# If the rule head was negated AND an ann_fn produced the bound, invert it:
+								# ~[l,u] = [1-u, 1-l]. For non-ann_fn negation the parser already folded
+								# the inversion into target_bound, so we must NOT re-invert here.
+								if rule.get_annotation_function() != '' and rule.is_head_negated():
 									bnd = (1 - bnd[1], 1 - bnd[0])
 								# Bound annotations in between 0 and 1
 								bnd_l = min(max(bnd[0], 0), 1)

--- a/pyreason/scripts/interpretation/interpretation_parallel.py
+++ b/pyreason/scripts/interpretation/interpretation_parallel.py
@@ -569,6 +569,9 @@ class Interpretation:
 								# If there is an edge to add or the predicate doesn't exist or the interpretation is not static
 								if rule.get_target() not in interpretations_node[n].world or not interpretations_node[n].world[rule.get_target()].is_static():
 									bnd = annotate(annotation_functions, rule, annotations, rule.get_weights())
+									# If the rule head was negated, invert the ann_fn output: ~[l,u] = [1-u, 1-l]
+									if rule.is_head_negated():
+										bnd = (1 - bnd[1], 1 - bnd[0])
 									# Bound annotations in between 0 and 1
 									bnd_l = min(max(bnd[0], 0), 1)
 									bnd_u = min(max(bnd[1], 0), 1)
@@ -588,6 +591,9 @@ class Interpretation:
 								# If there is an edge to add or the predicate doesn't exist or the interpretation is not static
 								if len(edges_to_add[0]) > 0 or rule.get_target() not in interpretations_edge[e].world or not interpretations_edge[e].world[rule.get_target()].is_static():
 									bnd = annotate(annotation_functions, rule, annotations, rule.get_weights())
+									# If the rule head was negated, invert the ann_fn output: ~[l,u] = [1-u, 1-l]
+									if rule.is_head_negated():
+										bnd = (1 - bnd[1], 1 - bnd[0])
 									# Bound annotations in between 0 and 1
 									bnd_l = min(max(bnd[0], 0), 1)
 									bnd_u = min(max(bnd[1], 0), 1)

--- a/pyreason/scripts/interpretation/interpretation_parallel.py
+++ b/pyreason/scripts/interpretation/interpretation_parallel.py
@@ -569,8 +569,10 @@ class Interpretation:
 								# If there is an edge to add or the predicate doesn't exist or the interpretation is not static
 								if rule.get_target() not in interpretations_node[n].world or not interpretations_node[n].world[rule.get_target()].is_static():
 									bnd = annotate(annotation_functions, rule, annotations, rule.get_weights())
-									# If the rule head was negated, invert the ann_fn output: ~[l,u] = [1-u, 1-l]
-									if rule.is_head_negated():
+									# If the rule head was negated AND an ann_fn produced the bound, invert it:
+									# ~[l,u] = [1-u, 1-l]. For non-ann_fn negation the parser already folded
+									# the inversion into target_bound, so we must NOT re-invert here.
+									if rule.get_annotation_function() != '' and rule.is_head_negated():
 										bnd = (1 - bnd[1], 1 - bnd[0])
 									# Bound annotations in between 0 and 1
 									bnd_l = min(max(bnd[0], 0), 1)
@@ -591,8 +593,10 @@ class Interpretation:
 								# If there is an edge to add or the predicate doesn't exist or the interpretation is not static
 								if len(edges_to_add[0]) > 0 or rule.get_target() not in interpretations_edge[e].world or not interpretations_edge[e].world[rule.get_target()].is_static():
 									bnd = annotate(annotation_functions, rule, annotations, rule.get_weights())
-									# If the rule head was negated, invert the ann_fn output: ~[l,u] = [1-u, 1-l]
-									if rule.is_head_negated():
+									# If the rule head was negated AND an ann_fn produced the bound, invert it:
+									# ~[l,u] = [1-u, 1-l]. For non-ann_fn negation the parser already folded
+									# the inversion into target_bound, so we must NOT re-invert here.
+									if rule.get_annotation_function() != '' and rule.is_head_negated():
 										bnd = (1 - bnd[1], 1 - bnd[0])
 									# Bound annotations in between 0 and 1
 									bnd_l = min(max(bnd[0], 0), 1)

--- a/pyreason/scripts/numba_wrapper/numba_types/rule_type.py
+++ b/pyreason/scripts/numba_wrapper/numba_types/rule_type.py
@@ -32,8 +32,8 @@ def typeof_rule(val, c):
 # Construct object from Numba functions (Doesn't work. We don't need this currently)
 @type_callable(Rule)
 def type_rule(context):
-    def typer(rule_name, type, target, head_variables, delta, clauses, bnd, thresholds, ann_fn, weights, head_fns, head_fns_vars, edges, static):
-        if isinstance(rule_name, types.UnicodeType) and isinstance(type, types.UnicodeType) and isinstance(target, label.LabelType) and isinstance(head_variables, types.ListType) and isinstance(delta, types.Integer) and isinstance(clauses, (types.NoneType, types.ListType)) and isinstance(bnd, interval.IntervalType) and isinstance(thresholds, types.ListType) and isinstance(ann_fn, types.UnicodeType) and isinstance(weights, types.Array) and isinstance(head_fns, types.ListType) and isinstance(head_fns_vars, types.ListType) and isinstance(edges, types.Tuple) and isinstance(static, types.Boolean):
+    def typer(rule_name, type, target, head_variables, delta, clauses, bnd, thresholds, ann_fn, weights, head_fns, head_fns_vars, edges, static, head_negated):
+        if isinstance(rule_name, types.UnicodeType) and isinstance(type, types.UnicodeType) and isinstance(target, label.LabelType) and isinstance(head_variables, types.ListType) and isinstance(delta, types.Integer) and isinstance(clauses, (types.NoneType, types.ListType)) and isinstance(bnd, interval.IntervalType) and isinstance(thresholds, types.ListType) and isinstance(ann_fn, types.UnicodeType) and isinstance(weights, types.Array) and isinstance(head_fns, types.ListType) and isinstance(head_fns_vars, types.ListType) and isinstance(edges, types.Tuple) and isinstance(static, types.Boolean) and isinstance(head_negated, types.Boolean):
             return rule_type
     return typer
 
@@ -57,6 +57,7 @@ class RuleModel(models.StructModel):
             ('head_fns_vars', types.ListType(types.ListType(types.string))),
             ('edges', types.Tuple((types.string, types.string, label.label_type))),
             ('static', types.boolean),
+            ('head_negated', types.boolean),
             ]
         models.StructModel.__init__(self, dmm, fe_type, members)
 
@@ -76,13 +77,14 @@ make_attribute_wrapper(RuleType, 'head_fns', 'head_fns')
 make_attribute_wrapper(RuleType, 'head_fns_vars', 'head_fns_vars')
 make_attribute_wrapper(RuleType, 'edges', 'edges')
 make_attribute_wrapper(RuleType, 'static', 'static')
+make_attribute_wrapper(RuleType, 'head_negated', 'head_negated')
 
 
 # Implement constructor
-@lower_builtin(Rule, types.string, types.string, label.label_type, types.ListType(types.string), types.uint16, types.ListType(types.Tuple((types.string, label.label_type, types.ListType(types.string), interval.interval_type, types.string))), interval.interval_type, types.ListType(types.Tuple((types.string, types.UniTuple(types.string, 2), types.float64))), types.string, types.float64[::1], types.ListType(types.string), types.ListType(types.ListType(types.string)), types.Tuple((types.string, types.string, label.label_type)), types.boolean)
+@lower_builtin(Rule, types.string, types.string, label.label_type, types.ListType(types.string), types.uint16, types.ListType(types.Tuple((types.string, label.label_type, types.ListType(types.string), interval.interval_type, types.string))), interval.interval_type, types.ListType(types.Tuple((types.string, types.UniTuple(types.string, 2), types.float64))), types.string, types.float64[::1], types.ListType(types.string), types.ListType(types.ListType(types.string)), types.Tuple((types.string, types.string, label.label_type)), types.boolean, types.boolean)
 def impl_rule(context, builder, sig, args):
     typ = sig.return_type
-    rule_name, type, target, head_variables, delta, clauses, bnd, thresholds, ann_fn, weights, head_fns, head_fns_vars, edges, static = args
+    rule_name, type, target, head_variables, delta, clauses, bnd, thresholds, ann_fn, weights, head_fns, head_fns_vars, edges, static, head_negated = args
     context.nrt.incref(builder, types.ListType(types.string), head_variables)
     context.nrt.incref(builder, types.ListType(types.Tuple((types.string, label.label_type, types.ListType(types.string), interval.interval_type, types.string))), clauses)
     context.nrt.incref(builder, types.ListType(types.Tuple((types.string, types.UniTuple(types.string, 2), types.float64))), thresholds)
@@ -104,6 +106,7 @@ def impl_rule(context, builder, sig, args):
     rule.head_fns_vars = head_fns_vars
     rule.edges = edges
     rule.static = static
+    rule.head_negated = head_negated
     return rule._getvalue()
 
 
@@ -213,6 +216,13 @@ def is_static_rule(rule):
     return impl
 
 
+@overload_method(RuleType, "is_head_negated")
+def is_head_negated(rule):
+    def impl(rule):
+        return rule.head_negated
+    return impl
+
+
 # Tell numba how to make native
 @unbox(RuleType)
 def unbox_rule(typ, obj, c):
@@ -230,6 +240,7 @@ def unbox_rule(typ, obj, c):
     head_fns_vars_obj = c.pyapi.object_getattr_string(obj, "_head_fns_vars")
     edges_obj = c.pyapi.object_getattr_string(obj, "_edges")
     static_obj = c.pyapi.object_getattr_string(obj, "_static")
+    head_negated_obj = c.pyapi.object_getattr_string(obj, "_head_negated")
     rule = cgutils.create_struct_proxy(typ)(c.context, c.builder)
     rule.rule_name = c.unbox(types.string, name_obj).value
     rule.type = c.unbox(types.string, type_obj).value
@@ -245,6 +256,7 @@ def unbox_rule(typ, obj, c):
     rule.head_fns_vars = c.unbox(types.ListType(types.ListType(types.string)), head_fns_vars_obj).value
     rule.edges = c.unbox(types.Tuple((types.string, types.string, label.label_type)), edges_obj).value
     rule.static = c.unbox(types.boolean, static_obj).value
+    rule.head_negated = c.unbox(types.boolean, head_negated_obj).value
     c.pyapi.decref(name_obj)
     c.pyapi.decref(type_obj)
     c.pyapi.decref(target_obj)
@@ -259,6 +271,7 @@ def unbox_rule(typ, obj, c):
     c.pyapi.decref(head_fns_vars_obj)
     c.pyapi.decref(edges_obj)
     c.pyapi.decref(static_obj)
+    c.pyapi.decref(head_negated_obj)
     is_error = cgutils.is_not_null(c.builder, c.pyapi.err_occurred())
     return NativeValue(rule._getvalue(), is_error=is_error)
 
@@ -281,7 +294,8 @@ def box_rule(typ, val, c):
     head_fns_vars_obj = c.box(types.ListType(types.ListType(types.string)), rule.head_fns_vars)
     edges_obj = c.box(types.Tuple((types.string, types.string, label.label_type)), rule.edges)
     static_obj = c.box(types.boolean, rule.static)
-    res = c.pyapi.call_function_objargs(class_obj, (name_obj, type_obj, target_obj, head_variables_obj, delta_obj, clauses_obj, bnd_obj, thresholds_obj, ann_fn_obj, weights_obj, head_fns_obj, head_fns_vars_obj, edges_obj, static_obj))
+    head_negated_obj = c.box(types.boolean, rule.head_negated)
+    res = c.pyapi.call_function_objargs(class_obj, (name_obj, type_obj, target_obj, head_variables_obj, delta_obj, clauses_obj, bnd_obj, thresholds_obj, ann_fn_obj, weights_obj, head_fns_obj, head_fns_vars_obj, edges_obj, static_obj, head_negated_obj))
     c.pyapi.decref(name_obj)
     c.pyapi.decref(type_obj)
     c.pyapi.decref(target_obj)
@@ -296,5 +310,6 @@ def box_rule(typ, val, c):
     c.pyapi.decref(head_fns_vars_obj)
     c.pyapi.decref(edges_obj)
     c.pyapi.decref(static_obj)
+    c.pyapi.decref(head_negated_obj)
     c.pyapi.decref(class_obj)
     return res

--- a/pyreason/scripts/rules/rule_internal.py
+++ b/pyreason/scripts/rules/rule_internal.py
@@ -1,6 +1,6 @@
 class Rule:
 
-    def __init__(self, rule_name, rule_type, target, head_variables, delta, clauses, bnd, thresholds, ann_fn, weights, head_fns, head_fns_vars, edges, static):
+    def __init__(self, rule_name, rule_type, target, head_variables, delta, clauses, bnd, thresholds, ann_fn, weights, head_fns, head_fns_vars, edges, static, head_negated=False):
         self._rule_name = rule_name
         self._type = rule_type
         self._target = target
@@ -15,6 +15,7 @@ class Rule:
         self._head_fns_vars = head_fns_vars
         self._edges = edges
         self._static = static
+        self._head_negated = head_negated
 
     def get_rule_name(self):
         return self._rule_name
@@ -66,6 +67,9 @@ class Rule:
 
     def is_static(self):
         return self._static
+
+    def is_head_negated(self):
+        return self._head_negated
 
     def __eq__(self, other):
         if not isinstance(other, Rule):

--- a/pyreason/scripts/utils/rule_parser.py
+++ b/pyreason/scripts/utils/rule_parser.py
@@ -81,8 +81,8 @@ def parse_rule(rule_text: str, name: str, custom_thresholds: Union[None, list, d
             custom_thresholds[i] = Threshold("greater_equal", ("percent", "total"), 100)
             body_clauses[i] = inner
 
-    # Parse the head: target predicate, bound, and annotation function
-    head, target_bound, ann_fn = _parse_head(head)
+    # Parse the head: target predicate, bound, annotation function, and head-negation flag
+    head, target_bound, ann_fn, head_negated = _parse_head(head)
 
     idx = head.find('(')
     target = head[:idx]
@@ -240,7 +240,7 @@ def parse_rule(rule_text: str, name: str, custom_thresholds: Union[None, list, d
             typed_vars_list.append(var)
         head_fns_vars_numba.append(typed_vars_list)
 
-    result = rule.Rule(name, rule_type, target, head_variables, numba.types.uint16(delta_t), clauses, target_bound, thresholds, ann_fn, weights, head_fns_numba, head_fns_vars_numba, edges, set_static)
+    result = rule.Rule(name, rule_type, target, head_variables, numba.types.uint16(delta_t), clauses, target_bound, thresholds, ann_fn, weights, head_fns_numba, head_fns_vars_numba, edges, set_static, head_negated)
     return result
 
 
@@ -367,6 +367,14 @@ def _parse_head(head):
     if colon_count > 1:
         raise ValueError(f"Rule head contains {colon_count} colons, expected at most 1")
 
+    # Strip a leading '~' up front so the suffix-handling below is uniform across
+    # all forms: ~pred(X), ~pred(X):[l,u], ~pred(X):True/False, ~pred(X):ann_fn.
+    # We apply the [1-u, 1-l] inversion to the resolved target_bound below.
+    negate_head_interval = False
+    if head[0] == '~':
+        head = head[1:]
+        negate_head_interval = True
+
     # Convert :True/:False shorthand to numeric bounds (case-insensitive)
     if colon_count == 1:
         colon_idx = head.index(':')
@@ -376,18 +384,9 @@ def _parse_head(head):
         elif suffix.lower() == 'false':
             head = head[:colon_idx] + ':[0,0]'
 
-    # If no colon present, attach default bound
-    negate_head_interval = False
+    # If no colon present, attach default bound [1,1] (negation will flip it to [0,0])
     if head[-1] == ')':
-        if head[0] == '~':
-            head += ':[0,0]'
-            head = head[1:]
-        else:
-            head += ':[1,1]'
-    elif head[0] == '~' and head[-1] == ']':
-        # ~pred(X):[l,u] — strip negation, keep explicit bound, flag for inversion
-        head = head[1:]
-        negate_head_interval = True
+        head += ':[1,1]'
 
     head_str, head_bound_str = head.split(':')
 
@@ -407,10 +406,13 @@ def _parse_head(head):
                 raise ValueError(
                     f"{e}. Note: Annotation function names cannot contain brackets '[' or ']'"
                 )
+        # Annotation function: default bound is [0,1]; ~[0,1] = [0,1] is a no-op
+        # at parse time. To actually invert the ann_fn's runtime output, the
+        # negate_head_interval flag must be plumbed onto Rule.
         target_bound = interval.closed(0, 1)
         ann_fn = head_bound_str
 
-    return head_str, target_bound, ann_fn
+    return head_str, target_bound, ann_fn, negate_head_interval
 
 
 def _parse_head_arguments(head_args_str):

--- a/tests/functional/test_advanced_features.py
+++ b/tests/functional/test_advanced_features.py
@@ -109,6 +109,32 @@ def test_annotation_function(mode):
 
 @pytest.mark.slow
 @pytest.mark.parametrize("mode", ["regular", "fp", "parallel"])
+def test_negated_annotation_function(mode):
+    """Negated head with an annotation function: the ann_fn output [l,u] must be
+    inverted to [1-u, 1-l] before being stored on the head atom."""
+    setup_mode(mode)
+
+    pr.settings.allow_ground_rules = True
+
+    pr.add_fact(pr.Fact('P(A) : [0.01, 1]'))
+    pr.add_fact(pr.Fact('P(B) : [0.2, 1]'))
+    pr.add_annotation_function(probability_func)
+    # probability_func returns (0.21, 1); negation should invert to [0, 0.79].
+    pr.add_rule(pr.Rule('~union_probability(A, B):probability_func <- P(A):[0, 1], P(B):[0, 1]', infer_edges=True))
+
+    interpretation = pr.reason(timesteps=1)
+
+    dataframes = pr.filter_and_sort_edges(interpretation, ['union_probability'])
+    for t, df in enumerate(dataframes):
+        print(f'TIMESTEP - {t}')
+        print(df)
+        print()
+
+    assert interpretation.query(pr.Query('union_probability(A, B) : [0, 0.79]')), 'Negated union probability should be [0, 0.79]'
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("mode", ["regular", "fp", "parallel"])
 def test_custom_thresholds(mode):
     """Test custom threshold functionality."""
     setup_mode(mode)

--- a/tests/functional/test_advanced_features.py
+++ b/tests/functional/test_advanced_features.py
@@ -135,6 +135,26 @@ def test_negated_annotation_function(mode):
 
 @pytest.mark.slow
 @pytest.mark.parametrize("mode", ["regular", "fp", "parallel"])
+def test_negated_head_without_annotation_function(mode):
+    """Regression: negated head with no ann_fn must not be inverted at runtime.
+
+    The parser already folds negation into target_bound (e.g. ~pred(X) -> [0,0]).
+    `annotate()` for an empty ann_fn just returns that stored bound, so applying
+    the runtime inversion again would double-invert and produce [1,1]."""
+    setup_mode(mode)
+    pr.settings.allow_ground_rules = True
+
+    pr.add_fact(pr.Fact('body(A) : [1, 1]'))
+    pr.add_rule(pr.Rule('~pred(A) <- body(A)', 'neg_no_ann'))
+
+    interpretation = pr.reason(timesteps=1)
+
+    bnd = interpretation.query(pr.Query('pred(A) : [0, 1]'), return_bool=False)
+    assert bnd == (0.0, 0.0), f'Expected [0, 0] for ~pred(A), got {bnd}'
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("mode", ["regular", "fp", "parallel"])
 def test_custom_thresholds(mode):
     """Test custom threshold functionality."""
     setup_mode(mode)

--- a/tests/unit/disable_jit/interpretations/test_old_interp_file.py
+++ b/tests/unit/disable_jit/interpretations/test_old_interp_file.py
@@ -226,6 +226,9 @@ def test_reason_applies_applicable_node_rule_with_trace_and_delta_zero(monkeypat
         def is_static_rule(self):
             return False
 
+        def is_head_negated(self):
+            return False
+
         def get_name(self):
             return "r"
 
@@ -354,6 +357,9 @@ def test_reason_applies_applicable_edge_rule_with_trace_and_delta_zero(monkeypat
             return edge_lbl
 
         def is_static_rule(self):
+            return False
+
+        def is_head_negated(self):
             return False
 
         def get_name(self):

--- a/tests/unit/disable_jit/interpretations/test_old_interp_file.py
+++ b/tests/unit/disable_jit/interpretations/test_old_interp_file.py
@@ -229,6 +229,9 @@ def test_reason_applies_applicable_node_rule_with_trace_and_delta_zero(monkeypat
         def is_head_negated(self):
             return False
 
+        def get_annotation_function(self):
+            return ""
+
         def get_name(self):
             return "r"
 
@@ -361,6 +364,9 @@ def test_reason_applies_applicable_edge_rule_with_trace_and_delta_zero(monkeypat
 
         def is_head_negated(self):
             return False
+
+        def get_annotation_function(self):
+            return ""
 
         def get_name(self):
             return "r"

--- a/tests/unit/dont_disable_jit/test_rule_parser.py
+++ b/tests/unit/dont_disable_jit/test_rule_parser.py
@@ -81,6 +81,19 @@ class TestValidRuleParsing:
         edges = r.get_edges()
         assert edges[2].get_value() == "avg"
 
+    def test_negation_with_annotation_function_head(self):
+        """Negated head with an annotation function — the '~' must be stripped
+        from the predicate name and the annotation function must still be captured."""
+        r = parse_rule(
+            "~hasLabel(CB, Lrisk):minimum_bounds_ann_fn <-0 hasLabel(CB, Lsafe):[0.7,1], mitigates(Lsafe, Lrisk)",
+            "neg_ann_head",
+            None,
+        )
+        assert r.get_target().get_value() == "hasLabel"
+        assert r.get_annotation_function() == "minimum_bounds_ann_fn"
+        assert r.get_rule_type() == "edge"
+        assert len(r.get_clauses()) == 2
+
     def test_explicit_head_bound(self):
         """Rule with explicit bound on head."""
         r = parse_rule("reliable(X):[0.8,1.0] <- tested(X):[0.9,1.0]", "hb", None)


### PR DESCRIPTION
## Summary
Allow a rule head to combine **negation** and an **annotation function**, e.g.

```
~hasLabel(CB, Lrisk):minimum_bounds_ann_fn <-0 hasLabel(CB, Lsafe):[0.7,1], mitigates(Lsafe, Lrisk)
```

Previously the parser rejected the rule because the leading `~` was not stripped when the head suffix was an ann_fn name (only the `)` and `]` cases were handled), so `~hasLabel` reached the predicate-name validator and was rejected.

This PR makes the parse succeed, plumbs a new `head_negated` flag through the `Rule` type, and applies the standard `~[l,u] = [1-u, 1-l]` inversion to the ann_fn's runtime output before it's stored on the head atom.

## What changed

**Parser** — `pyreason/scripts/utils/rule_parser.py`
- `_parse_head` now strips a leading `~` up front, so the suffix-handling logic is uniform across `~pred(X)`, `~pred(X):[l,u]`, `~pred(X):True/False`, and the new `~pred(X):ann_fn` case.
- Returns the negation flag alongside `target_bound` / `ann_fn`; `parse_rule` threads it into the `Rule` constructor.

**Rule type** — `pyreason/scripts/rules/rule_internal.py`, `pyreason/scripts/numba_wrapper/numba_types/rule_type.py`
- New `head_negated: bool` field with an `is_head_negated()` getter.
- Plumbed through the numba data model, attribute wrapper, `type_callable`, `lower_builtin`, `unbox`, and `box` so it survives JIT.

**Interpreters** — `interpretation.py`, `interpretation_fp.py`, `interpretation_parallel.py`
- After each `bnd = annotate(...)` call, if `rule.is_head_negated()`, transform `bnd → (1 - bnd[1], 1 - bnd[0])` *before* clamping to `[0,1]`. Two call sites per file (node + edge applicable rules), six patches total.

## Tests

- `tests/unit/dont_disable_jit/test_rule_parser.py::test_negation_with_annotation_function_head` — parser-level: target predicate `hasLabel`, `ann_fn = "minimum_bounds_ann_fn"`, edge rule, two body clauses.
- `tests/functional/test_advanced_features.py::test_negated_annotation_function` — E2E across `regular`/`fp`/`parallel`. `probability_func` returns `[0.21, 1]`; with the `~` prefix, the head atom is asserted to be `[0, 0.79]`.

All 110 parser tests still pass. The existing `test_annotation_function` (non-negated baseline) continues to pass in all three modes.

## Equivalence check (existing cases)

The parser refactor was confirmed equivalent to the prior logic for every existing form:

| Input | Pre-fix bound | Post-fix bound |
|---|---|---|
| `~pred(X)` | `[0,0]` | `[0,0]` |
| `~pred(X):[l,u]` | `[1-u, 1-l]` | `[1-u, 1-l]` |
| `~pred(X):True` | `[0,0]` | `[0,0]` |
| `~pred(X):False` | `[1,1]` | `[1,1]` |
| `~pred(X):ann_fn` | **rejected** | `[0,1]` at parse + runtime inversion |

## Notes

- `pyreason/.cache_status.yaml` flipped from `false` to `true` during local test runs — incidental, not part of the feature. Happy to revert if you'd prefer the file stay out of the diff.
- `yaml_parser.py` (deprecated) was left alone; its `Rule(...)` call already uses an outdated signature and is broken regardless of this change.

## Test plan
- [x] `pytest tests/unit/dont_disable_jit/test_rule_parser.py` — 110 passed
- [x] `pytest tests/functional/test_advanced_features.py::test_negated_annotation_function tests/functional/test_advanced_features.py::test_annotation_function` — 6 passed (3 modes × 2 tests)
