### PR TITLE
Peng/run natural reasoning

### DIFF
--- a/docs/source/tutorials/natural_language_to_pyreason.rst
+++ b/docs/source/tutorials/natural_language_to_pyreason.rst
@@ -1,18 +1,20 @@
-Natural Language to PyReason Tutorial
-======================================
+Natural Language to PyReason
+============================
 
-Welcome to the Natural Language to PyReason tutorial! In this document we outline
-a pipeline that converts a plain English paragraph into PyReason facts and rules
-using a Large Language Model (LLM). If you want to combine the flexibility of
-natural language input with the precision of symbolic reasoning, you're in the
-right place!
+Introduction
+------------
+In this tutorial, we use a Large Language Model (Ollama with a local model) to
+convert a plain English paragraph into PyReason facts and rules, validate them,
+and then run inference to produce conclusions back in English. This combines
+the flexibility of natural language input with the precision of symbolic
+reasoning.
 
 .. note::
    Find the full, executable code `here <https://github.com/lab-v2/pyreason/blob/main/examples/natural_language_to_pyreason_ex.py>`_
 
-The goal of this tutorial is to take a paragraph like this:
+The goal is to take a paragraph like this:
 
-::
+.. code:: text
 
    Carlos and Emma are both lawyers. All lawyers who win cases regularly tend to
    build a strong reputation. Emma wins cases regularly. Anyone with a strong
@@ -20,7 +22,10 @@ The goal of this tutorial is to take a paragraph like this:
    cases regularly.
 
 And automatically convert it into PyReason facts and rules, then validate that
-they parse correctly with PyReason.
+they parse correctly with PyReason. Once that works, the
+`Going Further: End-to-End Reasoning`_ section shows a wrapper script that
+extends the same pipeline to run ``pr.reason()`` and print the derived
+conclusions back in English.
 
 The pipeline needs three things:
 
@@ -30,10 +35,9 @@ The pipeline needs three things:
 
 Setup
 -----
-
 We use `Ollama <https://ollama.com>`_ to run an LLM locally. Different models
-have different trade-offs between speed and stability — we discuss this at the
-end of the tutorial. For this tutorial, we use ``qwen3:14b``.
+have different trade-offs between speed and stability — we discuss this in
+*Notes on Model Choice* below. For this tutorial, we use ``qwen3:14b``.
 
 1. Install Ollama from `ollama.com <https://ollama.com>`_
 2. Pull the model in terminal:
@@ -48,9 +52,8 @@ end of the tutorial. For this tutorial, we use ``qwen3:14b``.
 
    pip install ollama pyreason
 
-Step 1: Extract Facts and Rules in English
--------------------------------------------
-
+Extracting Facts and Rules in English
+-------------------------------------
 The first prompt asks the LLM to read the paragraph and produce structured
 English. No PyReason syntax appears yet — this step is purely about language
 understanding.
@@ -94,9 +97,9 @@ Three design choices in this prompt deserve attention:
    structured output rather than producing chatty preamble like "Sure, here are
    the facts I extracted...".
 
-For our example paragraph, the LLM produces:
+A typical response looks like:
 
-::
+.. code:: text
 
    Facts:
    - Carlos is a lawyer
@@ -108,12 +111,11 @@ For our example paragraph, the LLM produces:
    - All lawyers who win cases regularly tend to build a strong reputation
    - Anyone with a strong reputation is likely to attract high-profile clients
 
-Step 2: Convert to PyReason Syntax
------------------------------------
-
-The second prompt takes the English output from Step 1 and converts it into
-PyReason syntax. This is the harder step because PyReason's syntax rarely
-appears in LLM training data, so the prompt has to teach it.
+Converting to PyReason Syntax
+-----------------------------
+The second prompt takes the English output from the previous step and converts
+it into PyReason syntax. This is the harder step because PyReason's syntax
+rarely appears in LLM training data, so the prompt has to teach it.
 
 .. code:: python
 
@@ -136,7 +138,7 @@ appears in LLM training data, so the prompt has to teach it.
      1. Predicate names: lowercase_with_underscores, no spaces, no capital letters.
      2. Rule's head name describes WHAT, bound [l,u] describes HOW CERTAIN.
         Don't use uncertain name for rule's head.
-     3. Facts use specific names (john, mary) lower case is prefered in specific name.
+     3. Facts use specific names (john, mary) lower case is preferred in specific name.
         Rules use variables (X, Y).
      4. Negation in facts: use [0,0] on the SAME predicate, never invent a new predicate.
         e.g. "Alice is not student" -> student(alice):[0,0]  NOT not_student(alice):[1,1]
@@ -174,9 +176,9 @@ with ``<fact 1>`` / ``<rule 1>`` placeholders. This acts as a strong format
 anchor — the LLM sees the exact shape of the expected output and fills in the
 slots, which reduces format drift.
 
-For our example, the LLM produces:
+A typical response looks like:
 
-::
+.. code:: text
 
    Facts:
    lawyer(carlos):[1,1]
@@ -199,17 +201,16 @@ Notice how:
 - The two rules **chain**: rule 1's head ``strong_reputation`` appears
   verbatim in rule 2's body.
 
-Step 3: Validate with PyReason
--------------------------------
-
+Validating with PyReason
+------------------------
 After parsing the LLM output into a list of facts and rules, we check each
 rule by constructing a ``pr.Rule`` object. If PyReason's parser rejects it,
 we catch the error and report which rule failed.
 
 .. code:: python
-   
+
    import pyreason as pr
-   
+
    for rule in rules:
        try:
            pr.Rule(rule)
@@ -217,28 +218,19 @@ we catch the error and report which rule failed.
        except Exception as e:
            print(f"ERROR {rule}\n{e}")
 
-For our example, both rules pass:
-
-::
-
-   Validating rules...
-   Rule passed strong_reputation(X):[0.8,1] <- lawyer(X), wins_cases_regularly(X)
-   Rule passed attract_high_profile_clients(X):[0.8,1] <- strong_reputation(X)
-
 This validation step catches LLM mistakes early. If the LLM produced malformed
 syntax (an unbalanced parenthesis, a missing arrow, an invalid bound), the
 ``pr.Rule()`` constructor raises an exception and we see exactly which rule
 failed.
 
 Testing on Other Paragraphs
-----------------------------
-
+---------------------------
 The same pipeline handles paragraphs from any domain. Here are several test
 cases we used during development:
 
 **Medical**
 
-::
+.. code:: text
 
    Tom and Lisa are both nurses. All nurses who work night shifts tend to
    experience fatigue. Lisa works night shifts. Anyone who experiences
@@ -246,7 +238,7 @@ cases we used during development:
 
 **Animals**
 
-::
+.. code:: text
 
    Rex and Bella are both dogs. All dogs that exercise daily tend to stay
    healthy. Bella exercises daily. Any dog that stays healthy is likely to
@@ -254,7 +246,7 @@ cases we used during development:
 
 **Relational (Edge Rule)**
 
-::
+.. code:: text
 
    Alice and Bob are colleagues. All colleagues who share projects tend to
    collaborate well. Alice and Bob share a project. Anyone who collaborates
@@ -268,7 +260,6 @@ relationships, which the LLM must encode as edge facts like
 
 Notes on Model Choice
 ---------------------
-
 We tested several local Ollama models with the prompts above:
 
 - **llama3.1:8b** — fast but unstable. Often drops facts or invents predicates.
@@ -283,19 +274,77 @@ Smaller models are accessible but less reliable; larger models are reliable but
 require better hardware. The prompt design above mitigates the issue but cannot
 fully eliminate it.
 
-What's Next
+Going Further: End-to-End Reasoning
+-----------------------------------
+.. note::
+   Find the wrapper script `here <https://github.com/lab-v2/pyreason/blob/main/examples/run_natural_reasoning.py>`_
+
+The minimal example above stops after validating syntax. If you want a script
+that takes a paragraph in and prints derived conclusions back out in English,
+see ``run_natural_reasoning.py``. It extends the pipeline with three additional
+steps:
+
+4. Build a graph from the facts, load the rules, and run ``pr.reason()``.
+5. Split the reasoning results into **Input** (original facts that mattered)
+   and **Output** (newly derived conclusions). Entities that no rule ever
+   touched are hidden from the user entirely.
+6. A third LLM call summarizes each section back into natural English (for
+   example ``[0.8,1]`` becomes "80% likely").
+
+Install ``networkx`` in addition to the dependencies above:
+
+.. code:: bash
+
+   pip install networkx
+
+Run it and paste the same Carlos/Emma paragraph as before:
+
+.. code:: bash
+
+   python examples/run_natural_reasoning.py
+
+One subtlety worth flagging: PyReason defaults rule-body clause bounds to
+``[1,1]``, which means a rule with body ``strong_reputation(X)`` would not
+fire on an atom that derived to ``strong_reputation(X):[0.8,1]``. The wrapper
+relaxes body bounds to match each head bound in step 3, so inference chains
+keep firing across uncertain intermediate conclusions.
+
+Expected Output
+---------------
+For the minimal example, both rules pass validation:
+
+.. code:: text
+
+   Validating rules...
+   Rule passed strong_reputation(X):[0.8,1] <- lawyer(X), wins_cases_regularly(X)
+   Rule passed attract_high_profile_clients(X):[0.8,1] <- strong_reputation(X)
+
+For the end-to-end wrapper script, after the LLM finishes (roughly 1–3
+minutes), the output is split into two sections:
+
+.. code:: text
+
+   Input
+   Emma is a lawyer.
+   Emma wins cases regularly.
+
+   Output
+   Emma is 80% likely to attract high-profile clients.
+   Emma is 80% likely to have a strong reputation.
+
+Notice that Carlos does not appear at all. Because he does not win cases
+regularly, no rule fires on him, so no conclusions are derived — and the
+wrapper script hides facts about entities that never triggered a rule. Emma,
+on the other hand, satisfies the body of both rules, so the chained inference
+produces two derived conclusions about her.
+
+Limitations
 -----------
+This pipeline is intentionally minimal to illustrate the core idea. A few
+things worth keeping in mind:
 
-This pipeline is intentionally minimal to illustrate the core idea — taking
-natural language and turning it into PyReason syntax that parses correctly.
-Practical extensions could include:
-
-- Loading the validated facts and rules into a graph and running
-  ``pr.reason()`` to derive new conclusions.
-- A retry loop that catches syntax errors and asks the LLM to fix its own
-  output.
-- A post-inference step that translates PyReason's results back into natural
-  English.
-- Validation that detects predicate-naming drift across rules (e.g. rule 1's
-  head uses ``strong_reputation`` but rule 2's body uses
-  ``has_strong_reputation``) and prompts the LLM to unify the names.
+- The pipeline has been tested on short paragraphs with simple declarative
+  sentences. Free-form prose with pronouns, embedded clauses, or ambiguous
+  quantifiers may need prompt tuning.
+- The English summary renders ``[0.8,1]`` as "80% likely" for readability; the
+  raw PyReason output is the authoritative form.

--- a/examples/natural_language_to_pyreason_ex.py
+++ b/examples/natural_language_to_pyreason_ex.py
@@ -98,7 +98,7 @@ RULE syntax:
 Constraints:
   1. Predicate names: lowercase_with_underscores, no spaces, no capital letters.
   2. Rule's head name describes WHAT, bound [l,u] describes HOW CERTAIN. Don't use uncertain name for rule's head.
-  3. Facts use specific names (john, mary) lower case is prefered in specific name. Rules use variables (X, Y).
+  3. Facts use specific names (john, mary) lower case is preferred in specific name. Rules use variables (X, Y).
   4. Negation in facts: use [0,0] on the SAME predicate, never invent a new predicate.
      e.g. "Alice is not student" → student(alice):[0,0]  NOT not_student(alice):[1,1]
   5. Rules with one condition use only X: good_grade(X) <- study_hard(X)

--- a/examples/run_natural_reasoning.py
+++ b/examples/run_natural_reasoning.py
@@ -35,7 +35,7 @@ while True:
     lines.append(line)
 paragraph = " ".join(lines).strip()
 
-print("LLM is generating the conclusion... Please wait ~ 30 seconds")
+print("LLM is generating the conclusion... Please wait ~ 1-3 minutes")
 
 
 # Step 1: Extract facts and rules in English 
@@ -118,16 +118,16 @@ response_convert = ollama.chat(
     model=MODEL_NAME,
     messages=[{"role": "user", "content": PROMPT_CONVERT}]
 )
-pyreason_output = response_convert["message"]["content"]
+pyreason_output = response_convert["message"]["content"].strip()
 
 # Step 3: Parse the LLM output into facts and rules
 
 parts = re.split(
-    r'\*{0,2}\s*rules\s*\*{0,2}s*:?',
+    r'\*{0,2}\s*rules\s*\*{0,2}\s*:?',
     pyreason_output, maxsplit=1, flags=re.IGNORECASE
 )
 if len(parts) < 2:
-    print("Error: could not parse LLM output.")
+    print("ERROR: could not parse LLM output.")
     exit(1)
 
 facts_block, rules_block = parts[0], parts[1]
@@ -140,10 +140,10 @@ if not rules:
 
 # Relax rule body bounds:
 
-# Auto revise rules to allow inference fire later
-# PyReason set rule body clauses' bounds default as [1,1]
-# If last rule inferences strong_reputation(X):[0.8,1]
-# Next rule uses strong_reputation(X) as body, the rule will never fire because [0.8,1] not = [1,1]
+# Auto-revise rules so inference chains can fire correctly
+# PyReason defaults rule body clause bounds to [1,1]
+# If the last rule derives strong_reputation(X):[0.8,1]
+# Next rule uses strong_reputation(X) as body, the rule will never fire because [0.8,1] not equals to [1,1]
 
 # Record the head bound of every rule.
 head_bounds = {}
@@ -275,8 +275,7 @@ Each line is: predicate(entity):[lower, upper]
 Write ONE short English sentence per line:
 - [1.0, 1.0] = certain.   e.g. "Leo works overtime."
 - [0.0, 0.0] = false.     e.g. "Mia does not work overtime."
-- lower >= 0.5, upper = 1.0 = likely.  e.g. "Leo is 80% likely to manage projects."
-- Skip lines with [0.0, 1.0] (no information).
+- work_overtime(peng):[0.8,1.0] e.g. "Peng is 80% likely to work overtime."
  
 Other rules:
 - Capitalize entity names (alice -> Alice).
@@ -302,5 +301,5 @@ Output:
 print("\nInput")
 print(summarize(input_lines))
 
-print("\nOutputs")
+print("\nOutput")
 print(summarize(output_lines))

--- a/examples/run_natural_reasoning.py
+++ b/examples/run_natural_reasoning.py
@@ -16,3 +16,16 @@ import io
 
 MODEL_NAME = "qwen3:14b"
 
+# Read User Input
+print("\nEnter text:")
+lines = []
+while True:
+    line = input()
+    if line == "" and lines:
+        break
+    lines.append(line)
+paragraph = " ".join(lines).strip()
+
+print("LLM is generating the conclusion... Please wait ~ 30 seconds")
+
+

--- a/examples/run_natural_reasoning.py
+++ b/examples/run_natural_reasoning.py
@@ -1,10 +1,19 @@
 """
+Natural Language Reasoning with PyReason
+=========================================
+Wrapper script: user inputs a structured paragraph, sees reasoning results in English.
+
 Pipeline:
-Natural Language -> Logic -> Natural Language:
-User inputs English paragraph, the scipt calls LLM to extract Facts and Rules.
-Then calls LLM again to convert the Facts and Rules to PyReason Syntax.
-And run the PyReason Inference.
-Lastly, calls LLM again to "translate" the inference result in English as outputs.
+    Step 1: LLM extracts facts and rules in plain English
+    Step 2: LLM converts English into PyReason syntax
+    Step 3: Parse the LLM output
+    Step 4: Build graph, load facts/rules, run pr.reason()
+    Step 5: Split results into Input (relevant facts) and Output (derived conclusions)
+    Step 6: LLM summarizes each section in natural English
+
+Setup:
+    1. ollama pull qwen3:14b
+    2. pip install ollama pyreason networkx
 """
 
 import ollama

--- a/examples/run_natural_reasoning.py
+++ b/examples/run_natural_reasoning.py
@@ -97,7 +97,7 @@ RULE syntax:
 Constraints:
   1. Predicate names: lowercase_with_underscores, no spaces, no capital letters.
   2. Rule's head name describes WHAT, bound [l,u] describes HOW CERTAIN. Don't use uncertain name for rule's head.
-  3. Facts use specific names (john, mary) lower case is prefered in specific name. Rules use variables (X, Y).
+  3. Facts use specific names (john, mary) lower case is preferred in specific name. Rules use variables (X, Y).
   4. Negation in facts: use [0,0] on the SAME predicate, never invent a new predicate.
      e.g. "Alice is not student" → student(alice):[0,0]  NOT not_student(alice):[1,1]
   5. Rules with one condition use only X: good_grade(X) <- study_hard(X)

--- a/examples/run_natural_reasoning.py
+++ b/examples/run_natural_reasoning.py
@@ -12,8 +12,11 @@ Pipeline:
     Step 6: LLM summarizes each section in natural English
 
 Setup:
-    1. ollama pull qwen3:14b
-    2. pip install ollama pyreason networkx
+    1. Install Ollama from https://ollama.com
+    2. Pull the recommended model on terminal:
+           ollama pull qwen3:14b
+    3. Install Python dependencies:
+           pip install ollama pyreason networkx
 """
 
 import ollama

--- a/examples/run_natural_reasoning.py
+++ b/examples/run_natural_reasoning.py
@@ -253,3 +253,45 @@ output_lines = [
     f"{label}({','.join(ents)}):{bound}"
     for label, ents, bound in derived
 ]
+
+# Step 6: LLM summarizes each section
+# Send input_lines and output_lines to LLM, "translate" to Natural Language
+def summarize(reasoning_lines):
+    """Send reasoning lines to LLM and return natural-English sentences."""
+    if not reasoning_lines:
+        return ""
+    prompt = f"""Below are reasoning results from a logic engine.
+Each line is: predicate(entity):[lower, upper]
+ 
+Write ONE short English sentence per line:
+- [1.0, 1.0] = certain.   e.g. "Leo works overtime."
+- [0.0, 0.0] = false.     e.g. "Mia does not work overtime."
+- lower >= 0.5, upper = 1.0 = likely.  e.g. "Leo is 80% likely to manage projects."
+- Skip lines with [0.0, 1.0] (no information).
+ 
+Other rules:
+- Capitalize entity names (alice -> Alice).
+- Convert snake_case predicates to readable English (works_overtime -> "works overtime").
+- Use correct verb forms ("does not work", not "does not works").
+- For single-word noun predicates (engineer, doctor, dog), use "is a/an".
+- ONLY use the data given. Do NOT invent.
+- Output one sentence per line, no headings, no bullets.
+ 
+Reasoning results:
+{chr(10).join(reasoning_lines)}
+ 
+Output:
+"""
+    
+    response = ollama.chat(
+        model=MODEL_NAME,
+        messages=[{"role": "user", "content": prompt}]
+    )
+
+    return response["message"]["content"].strip()
+
+print("\nInput")
+print(summarize(input_lines))
+
+print("\nOutputs")
+print(summarize(output_lines))

--- a/examples/run_natural_reasoning.py
+++ b/examples/run_natural_reasoning.py
@@ -130,6 +130,7 @@ if not rules:
     exit(1)
 
 # Relax rule body bounds:
+
 # Auto revise rules to allow inference fire later
 # PyReason set rule body clauses' bounds default as [1,1]
 # If last rule inferences strong_reputation(X):[0.8,1]
@@ -182,3 +183,73 @@ for f in facts:
     if len(names) == 2:
         g.add_edge(names[0], names[1])
 pr.load_graph(g)
+
+for f in facts:
+    pr.add_fact(pr.Fact(f))
+for r in rules:
+    pr.add_rule(pr.Rule(r))
+
+# Run reasoning silently
+pr.settings.verbose = False
+_buf = io.StringIO()
+_old_stdout = sys.stdout
+sys.stdout = _buf
+interpretation = pr.reason(timesteps=2)
+sys.stdout = _old_stdout
+
+# Step 5: Split the reasoning results into Input and Output
+
+# Input  = original facts about entities that triggered at least one rule
+# Output = new conclusions derived by rule firings
+# Entities that never triggered a rule are hidden from the user entirely.
+ 
+# Original (predicate, entities) pairs the user gave us.
+original_atoms = set()
+for f in facts:
+    original_atoms.add((predicate_of(f), entities_of(f)))
+ 
+# Predicate names that appear anywhere, split by arity.
+node_labels, edge_labels = set(), set()
+for atom in facts + [r.split('<-')[0] for r in rules]:
+    args = entities_of(atom)
+    if len(args) == 1:
+        node_labels.add(predicate_of(atom))
+    elif len(args) == 2:
+        edge_labels.add(predicate_of(atom))
+ 
+# Walk PyReason results: collect derived conclusions and mark useful entities.
+derived = []
+useful_entities = set()
+ 
+for label in sorted(node_labels):
+    for df in pr.filter_and_sort_nodes(interpretation, [label]):
+        for _, row in df.iterrows():
+            entity = row['component']
+            bound = row[label]
+            key = (label, (entity,))
+            if key not in original_atoms:
+                derived.append((label, (entity,), bound))
+                useful_entities.add(entity)
+ 
+for label in sorted(edge_labels):
+    for df in pr.filter_and_sort_edges(interpretation, [label]):
+        for _, row in df.iterrows():
+            e = row['component']
+            bound = row[label]
+            key = (label, (e[0], e[1]))
+            if key not in original_atoms:
+                derived.append((label, (e[0], e[1]), bound))
+                useful_entities.add(e[0])
+                useful_entities.add(e[1])
+ 
+# Input facts: keep only those involving a useful entity.
+input_lines = [
+    f for f in facts
+    if any(e in useful_entities for e in entities_of(f))
+]
+ 
+# Output conclusions: every derived atom.
+output_lines = [
+    f"{label}({','.join(ents)}):{bound}"
+    for label, ents, bound in derived
+]

--- a/examples/run_natural_reasoning.py
+++ b/examples/run_natural_reasoning.py
@@ -29,3 +29,85 @@ paragraph = " ".join(lines).strip()
 print("LLM is generating the conclusion... Please wait ~ 30 seconds")
 
 
+# Step 1: Extract facts and rules in English 
+# Ask LLM to read the paragraph and split it into:
+#   - Facts: specific statements about a named person, place, or thing
+#   - Rules: general IF-THEN patterns that apply to anyone
+
+PROMPT_EXTRACT = f"""Read the paragraph below and extract two things.
+FACTS: specific statements about a named person, place, or thing.
+  - Extract EVERY fact mentioned, including type/category facts like "A is a student". Do not skip any.
+  - Include negative facts too (e.g. "John does not study regularly")
+  - Only extract what is explicitly stated, do not assume or invent
+RULES: general IF-THEN patterns that apply to any person or thing.
+  - These are generalizations, not about one specific person
+ 
+Output exactly this format, no extra text:
+ 
+Facts:
+- <fact 1>
+- <fact 2>
+ 
+Rules:
+- <rule 1>
+- <rule 2>
+ 
+Paragraph: {paragraph}
+ 
+Facts:
+"""
+
+response_extract = ollama.chat(
+    model=MODEL_NAME,
+    messages=[{"role": "user", "content": PROMPT_EXTRACT}]
+)
+english_output = response_extract["message"]["content"].strip()
+
+# Step 2: Convert English facts and rules into PyReason syntax
+# Now we teach the LLM the PyReason syntax via examples and constraints,
+# Then ask it to convert the English output from Step 1.
+
+PROMPT_CONVERT = f"""Convert the facts and rules below into PyReason syntax.
+ 
+FACT syntax and examples:
+  predicate(node):[l,u]
+  predicate(node):[1,1] ([1,1] means completely true)           e.g. student(alice):[1,1] (Alice is a student)
+  predicate(node):[0,0] ([0,0] means completely false)          e.g. student(marie):[0,0] (Marie is not a student)
+  predicate(node):[0.8,1] ([0.8,1] means likely, "tend to", "usually") e.g. doctor(bob):[0.8,1] (Bob is likely a doctor)
+  predicate(node1,node2):[1,1]     e.g. enrolled_in(ryan,cs):[1,1] (Ryan enrolled in cs major)
+  
+RULE syntax:
+  head(X):[bound] <- condition1(X), condition2(X,Y)
+  Use variables X, Y (never specific names):
+  example: grandparent(X,Y) <- parent(X,Z), parent(Z,Y)
+  Include ALL conditions from the English rule, even if they seem redundant.
+ 
+Constraints:
+  1. Predicate names: lowercase_with_underscores, no spaces, no capital letters.
+  2. Rule's head name describes WHAT, bound [l,u] describes HOW CERTAIN. Don't use uncertain name for rule's head.
+  3. Facts use specific names (john, mary) lower case is prefered in specific name. Rules use variables (X, Y).
+  4. Negation in facts: use [0,0] on the SAME predicate, never invent a new predicate.
+     e.g. "Alice is not student" → student(alice):[0,0]  NOT not_student(alice):[1,1]
+  5. Rules with one condition use only X: good_grade(X) <- study_hard(X)
+     Only introduce Y or Z when two different entities are involved.
+
+### No markdown, no code blocks, no comments. Output ONLY the two sections.
+ 
+Facts and rules to convert:
+{english_output}
+ 
+Facts:
+<fact 1>
+<fact 2>
+ 
+Rules:
+<rule 1>
+<rule 2>
+"""
+
+response_convert = ollama.chat(
+    model=MODEL_NAME,
+    messages=[{"role": "user", "content": PROMPT_CONVERT}]
+)
+pyreason_output = response_convert["message"]["content"]
+

--- a/examples/run_natural_reasoning.py
+++ b/examples/run_natural_reasoning.py
@@ -173,3 +173,12 @@ def entities_of(atom):
     if not m:
         return ()
     return tuple(n.strip() for n in m.group(1).split(',') if n.strip())
+
+# Step 4: Build graph and run PyReason
+g = nx.DiGraph()
+for f in facts:
+    names = entities_of(f)
+    g.add_nodes_from(names)
+    if len(names) == 2:
+        g.add_edge(names[0], names[1])
+pr.load_graph(g)

--- a/examples/run_natural_reasoning.py
+++ b/examples/run_natural_reasoning.py
@@ -111,3 +111,22 @@ response_convert = ollama.chat(
 )
 pyreason_output = response_convert["message"]["content"]
 
+# Step 3: Parse the LLM output into facts and rules
+
+parts = re.split(
+    r'\*{0,2}\s*rules\s*\*{0,2}s*:?',
+    pyreason_output, maxsplit=1, flags=re.IGNORECASE
+)
+if len(parts) < 2:
+    print("Error: could not parse LLM output.")
+    exit(1)
+
+facts_block, rules_block = parts[0], parts[1]
+facts = [l.strip() for l in facts_block.split("\n") if "):" in l]
+rules = [l.strip() for l in rules_block.split("\n") if "<-" in l]
+
+if not rules:
+    print("ERROR: No rules extracted.")
+    exit(1)
+    
+         

--- a/examples/run_natural_reasoning.py
+++ b/examples/run_natural_reasoning.py
@@ -1,0 +1,18 @@
+"""
+Pipeline:
+Natural Language -> Logic -> Natural Language:
+User inputs English paragraph, the scipt calls LLM to extract Facts and Rules.
+Then calls LLM again to convert the Facts and Rules to PyReason Syntax.
+And run the PyReason Inference.
+Lastly, calls LLM again to "translate" the inference result in English as outputs.
+"""
+
+import ollama
+import pyreason as pr
+import networkx as nx
+import re
+import sys
+import io
+
+MODEL_NAME = "qwen3:14b"
+

--- a/examples/run_natural_reasoning.py
+++ b/examples/run_natural_reasoning.py
@@ -128,5 +128,48 @@ rules = [l.strip() for l in rules_block.split("\n") if "<-" in l]
 if not rules:
     print("ERROR: No rules extracted.")
     exit(1)
-    
-         
+
+# Relax rule body bounds:
+# Auto revise rules to allow inference fire later
+# PyReason set rule body clauses' bounds default as [1,1]
+# If last rule inferences strong_reputation(X):[0.8,1]
+# Next rule uses strong_reputation(X) as body, the rule will never fire because [0.8,1] not = [1,1]
+
+# Record the head bound of every rule.
+head_bounds = {}
+for r in rules:
+    head = r.split('<-')[0].strip()
+    pred = head.split('(')[0].lstrip('~').strip()
+    m = re.search(r':\[([^\]]+)\]', head)
+    if m:
+        head_bounds[pred] = m.group(1)
+
+def relax_body(rule_text):
+    """If a body clause references a derived predicate, copy its head bound."""
+    head, body = rule_text.split('<-', 1)
+    clauses = [c.strip() for c in body.split(',')]
+    fixed = []
+    for c in clauses:
+        if ':' in c:
+            fixed.append(c)
+            continue
+        pred = c.split('(')[0].lstrip('~').strip()
+        if pred in head_bounds:
+            fixed.append(f"{c}:[{head_bounds[pred]}]")
+        else:
+            fixed.append(c)
+    return f"{head.strip()} <- {', '.join(fixed)}"
+
+rules = [relax_body(r) for r in rules]
+
+# Helper Functions
+def predicate_of(atom):
+    """Return the predicate name from 'pred(args):[l,u]' or 'pred(args)'."""
+    return atom.split('(')[0].lstrip('~').strip()
+
+def entities_of(atom):
+    """Return a tuple of entity names from inside the parentheses."""
+    m = re.search(r'\(([^)]*)\)', atom)
+    if not m:
+        return ()
+    return tuple(n.strip() for n in m.group(1).split(',') if n.strip())


### PR DESCRIPTION
## Summary
Per Kaustuv's feedback, add a wrapper script that takes a user-input paragraph, runs the full natural language → PyReason → natural language pipeline, and prints the reasoning results split into `Input` and `Output` sections.

## Changes and next steps
- New file: `examples/run_natural_reasoning.py`
- will remove old natural_language_to_pyreason_ex.py if needed
- will revise the tutorial file after this script gets approval and finalize

## Pipeline
1. **Step 1** — LLM extracts facts and rules in plain English from the paragraph
2. **Step 2** — LLM converts English facts/rules into PyReason syntax
3. **Step 3** — Parser splits the LLM output into a facts list and a rules list
4. **Relax body bounds** — auto-revise rule bodies so probabilistic conclusions can chain across rules (PyReason's default `[1,1]` body bound blocks `[0.8,1]` derivations from chaining)
5. **Step 4** — Build a NetworkX graph from the entities, load facts/rules into PyReason, run `pr.reason()`
6. **Step 5** — Split results into `Input` (relevant facts) and `Output` (derived conclusions). Entities for which no rule fired are filtered out
7. **Step 6** — LLM translates each section back into natural English with proper grammar and percentage formatting


## Example Output

**Lawyer paragraph**:
<img width="1984" height="486" alt="image" src="https://github.com/user-attachments/assets/d8c1fd9f-adff-4d88-a98c-5ae7d40d830d" />

**Nurse paragraph**:
<img width="2001" height="498" alt="image" src="https://github.com/user-attachments/assets/b0e7e42b-9cd3-4db7-a260-cf4f7845ffb7" />
