### PR TITLE
fix: resolve Interval constructor arity and Fact attributes when JIT is disabled

### DIFF
--- a/pyreason/scripts/facts/fact_edge.py
+++ b/pyreason/scripts/facts/fact_edge.py
@@ -8,6 +8,7 @@ class Fact:
         self._label = label
         self._interval = interval
         self._static = static
+        self.static = static
 
     def get_name(self):
         return self._name

--- a/pyreason/scripts/facts/fact_node.py
+++ b/pyreason/scripts/facts/fact_node.py
@@ -8,6 +8,7 @@ class Fact:
         self._label = label
         self._interval = interval
         self._static = static
+        self.static = static
 
     def get_name(self):
         return self._name

--- a/pyreason/scripts/interval/interval.py
+++ b/pyreason/scripts/interval/interval.py
@@ -4,7 +4,17 @@ import numpy as np
 
 
 class Interval(structref.StructRefProxy):
-    def __new__(cls, lower, upper, s=False):
+    def __new__(cls, lower, upper, s=False, *args):
+        if len(args) == 2:
+            prev_lower, prev_upper = args
+            obj = object.__new__(cls)
+            obj.l = lower
+            obj.u = upper
+            obj.s = s
+            obj.prev_l = prev_lower
+            obj.prev_u = prev_upper
+            return obj
+
         return structref.StructRefProxy.__new__(cls, lower, upper, s, lower, upper)
 
     @property
@@ -66,7 +76,7 @@ class Interval(structref.StructRefProxy):
         if lower > upper:
             lower = np.float64(0)
             upper = np.float64(1)
-        return Interval(lower, upper, False, self.lower, self.upper)
+        return Interval(lower, upper, False)
 
     def to_str(self):
         return self.__repr__()

--- a/pyreason/scripts/numba_wrapper/numba_types/interval_type.py
+++ b/pyreason/scripts/numba_wrapper/numba_types/interval_type.py
@@ -142,4 +142,4 @@ def interval_contains(interval_1, interval_2):
 
 @njit
 def closed(lower, upper, static=False):
-    return Interval(np.float64(lower), np.float64(upper), static, np.float64(lower), np.float64(upper))
+    return Interval(np.float64(lower), np.float64(upper), static)


### PR DESCRIPTION
### Description
Fixes a fatal `TypeError` and `AttributeError` that occurs when importing or executing PyReason with JIT compilation disabled (`NUMBA_DISABLE_JIT=1`). This unbricks the interpreted fallback layer and allows the `disable_jit` unit test suite to run successfully.

### Changes:

- Interval Proxy Arity: Intercepted variable arguments (`*args`) in `Interval.__new__` to gracefully handle Numba's uncompiled reconstruction loop, and aligned the factory instantiation signature in `interval_type.py`.

- Fact Model Attributes: Added public `.static` field assignment to both Python `Fact` class constructors to match expected access hooks during interpreted fact initialization.

Fixes #158 
Signed off : abhiprd2000